### PR TITLE
HOP-107

### DIFF
--- a/core/src/main/java/org/apache/hop/core/Const.java
+++ b/core/src/main/java/org/apache/hop/core/Const.java
@@ -1924,7 +1924,7 @@ public class Const {
       Enumeration<InetAddress> ip = nwi.getInetAddresses();
       while ( ip.hasMoreElements() ) {
         InetAddress in = ip.nextElement();
-        if ( !in.isLoopbackAddress() && in.toString().indexOf( ":" ) < 0 ) {
+        if ( !in.isLoopbackAddress() && in.toString().indexOf( ':' ) < 0 ) {
           return in.getHostAddress();
         }
       }
@@ -1944,7 +1944,7 @@ public class Const {
     Enumeration<InetAddress> ipAddresses = networkInterface.getInetAddresses();
     while ( ipAddresses.hasMoreElements() ) {
       InetAddress inetAddress = ipAddresses.nextElement();
-      if ( !inetAddress.isLoopbackAddress() && inetAddress.toString().indexOf( ":" ) < 0 ) {
+      if ( !inetAddress.isLoopbackAddress() && inetAddress.toString().indexOf( ':' ) < 0 ) {
         String hostname = inetAddress.getHostAddress();
         return hostname;
       }

--- a/core/src/main/java/org/apache/hop/core/DBCache.java
+++ b/core/src/main/java/org/apache/hop/core/DBCache.java
@@ -141,12 +141,7 @@ public class DBCache {
       if ( file.canRead() ) {
         log.logDetailed( "Loading database cache from file: [" + filename + "]" );
 
-        FileInputStream fis = null;
-        DataInputStream dis = null;
-
-        try {
-          fis = new FileInputStream( file );
-          dis = new DataInputStream( fis );
+        try (FileInputStream fis = new FileInputStream( file );  DataInputStream dis = new DataInputStream( fis ) ) {
           int counter = 0;
           try {
             while ( true ) {
@@ -160,11 +155,7 @@ public class DBCache {
           }
         } catch ( Exception e ) {
           throw new Exception( e );
-        } finally {
-          if ( dis != null ) {
-            dis.close();
-          }
-        }
+        } 
       } else {
         log.logDetailed( "The database cache doesn't exist yet." );
       }
@@ -180,18 +171,13 @@ public class DBCache {
       String filename = getFilename();
       File file = new File( filename );
       if ( !file.exists() || file.canWrite() ) {
-        FileOutputStream fos = null;
-        DataOutputStream dos = null;
 
-        try {
-          fos = new FileOutputStream( file );
-          dos = new DataOutputStream( new BufferedOutputStream( fos, 10000 ) );
+        try (FileOutputStream fos = new FileOutputStream( file ); DataOutputStream dos =new DataOutputStream( new BufferedOutputStream( fos, 10000 ) ) ) {
 
-          int counter = 0;
-          boolean ok = true;
+          int counter = 0;         
 
           Enumeration<DBCacheEntry> keys = cache.keys();
-          while ( ok && keys.hasMoreElements() ) {
+          while ( keys.hasMoreElements() ) {
             // Save the database cache entry
             DBCacheEntry entry = keys.nextElement();
             entry.write( dos );
@@ -209,10 +195,6 @@ public class DBCache {
           log.logDetailed( "We wrote " + counter + " cached rows to the database cache!" );
         } catch ( Exception e ) {
           throw new Exception( e );
-        } finally {
-          if ( dos != null ) {
-            dos.close();
-          }
         }
       } else {
         throw new HopFileException( "We can't write to the cache file: " + filename );

--- a/core/src/main/java/org/apache/hop/core/DBCacheEntry.java
+++ b/core/src/main/java/org/apache/hop/core/DBCacheEntry.java
@@ -78,12 +78,10 @@ public class DBCacheEntry {
 
   @Override
   public boolean equals( Object o ) {
-    if ( ( null != o ) && ( o instanceof DBCacheEntry ) ) {
+    if ( o instanceof DBCacheEntry ) {
       DBCacheEntry obj = (DBCacheEntry) o;
 
-      boolean retval = dbname.equalsIgnoreCase( obj.dbname ) && sql.equalsIgnoreCase( obj.sql );
-
-      return retval;
+      return dbname.equalsIgnoreCase( obj.dbname ) && sql.equalsIgnoreCase( obj.sql );
     }
     return false;
   }

--- a/core/src/main/java/org/apache/hop/core/HopClientEnvironment.java
+++ b/core/src/main/java/org/apache/hop/core/HopClientEnvironment.java
@@ -226,27 +226,14 @@ public class HopClientEnvironment {
     String kpFile = directory + Const.FILE_SEPARATOR + Const.HOP_PROPERTIES;
     File file = new File( kpFile );
     if ( !file.exists() ) {
-      FileOutputStream out = null;
-      try {
-        out = new FileOutputStream( file );
+      try (FileOutputStream out =  new FileOutputStream( file ) ) {       
         out.write( Const.getHopPropertiesFileHeader().getBytes() );
       } catch ( IOException e ) {
         System.err
           .println( BaseMessages.getString(
             PKG, "Props.Log.Error.UnableToCreateDefaultHopProperties.Message", Const.HOP_PROPERTIES,
             kpFile ) );
-        System.err.println( e.getStackTrace() );
-      } finally {
-        if ( out != null ) {
-          try {
-            out.close();
-          } catch ( IOException e ) {
-            System.err.println( BaseMessages.getString(
-              PKG, "Props.Log.Error.UnableToCreateDefaultHopProperties.Message", Const.HOP_PROPERTIES,
-              kpFile ) );
-            System.err.println( e.getStackTrace() );
-          }
-        }
+        System.err.println( e.getStackTrace() );      
       }
     }
   }

--- a/core/src/main/java/org/apache/hop/core/Props.java
+++ b/core/src/main/java/org/apache/hop/core/Props.java
@@ -211,7 +211,7 @@ public class Props implements Cloneable {
     filename = getFilename();
     createLogChannel();
     properties = new Properties();
-    pluginHistory = new ArrayList<ObjectUsageCount>();
+    pluginHistory = new ArrayList<>();
 
     loadProps();
     addDefaultEntries();
@@ -246,17 +246,8 @@ public class Props implements Cloneable {
   }
 
   public boolean loadProps() {
-    try {
-      FileInputStream fis = new FileInputStream( filename );
-      try {
+    try ( FileInputStream fis = new FileInputStream( filename ) ) {     
         properties.load( fis );
-      } finally {
-        try {
-          fis.close();
-        } catch ( IOException ignored ) {
-          // Ignore close exception
-        }
-      }
     } catch ( Exception e ) {
       return false;
     }
@@ -304,8 +295,7 @@ public class Props implements Cloneable {
   }
 
   public String getLogLevel() {
-    String level = properties.getProperty( STRING_LOG_LEVEL, "Basic" );
-    return level;
+    return properties.getProperty( STRING_LOG_LEVEL, "Basic" );
   }
 
   public void setLogFilter( String filter ) {
@@ -313,8 +303,7 @@ public class Props implements Cloneable {
   }
 
   public String getLogFilter() {
-    String level = properties.getProperty( STRING_LOG_FILTER, "" );
-    return level;
+    return properties.getProperty( STRING_LOG_FILTER, "" );
   }
 
   public void setUseDBCache( boolean use ) {
@@ -477,7 +466,7 @@ public class Props implements Cloneable {
    * Load the plugin history from the properties file
    */
   protected void loadPluginHistory() {
-    pluginHistory = new ArrayList<ObjectUsageCount>();
+    pluginHistory = new ArrayList<>();
     int i = 0;
     String string = properties.getProperty( STRING_PLUGIN_HISTORY + "_" + i );
     while ( string != null ) {

--- a/core/src/main/java/org/apache/hop/core/util/EnvUtil.java
+++ b/core/src/main/java/org/apache/hop/core/util/EnvUtil.java
@@ -44,6 +44,9 @@ import java.util.TimeZone;
 public class EnvUtil {
   private static Properties env = null;
 
+  private EnvUtil() {		 
+  }
+  
   /**
    * Returns the properties from the users kettle home directory.
    *
@@ -59,20 +62,10 @@ public class EnvUtil {
 
   private static Properties readPropertiesByFullPath( final String fileName ) throws HopException {
     Properties props = new Properties();
-    InputStream is = null;
-    try {
-      is = new FileInputStream( fileName );
+    try (InputStream is = new FileInputStream( fileName ) )  {
       props.load( is );
     } catch ( IOException ioe ) {
-      throw new HopException( "Unable to read file '" + fileName + "'", ioe );
-    } finally {
-      if ( is != null ) {
-        try {
-          is.close();
-        } catch ( IOException e ) {
-          // ignore
-        }
-      }
+      throw new HopException( "Unable to read file '" + fileName + "'", ioe );    
     }
     return props;
   }
@@ -222,7 +215,7 @@ public class EnvUtil {
     addInternalVariables( sysprops );
 
     String[] envp = new String[ sysprops.size() ];
-    List<Object> list = new ArrayList<Object>( sysprops.keySet() );
+    List<Object> list = new ArrayList<>( sysprops.keySet() );
     for ( int i = 0; i < list.size(); i++ ) {
       String var = (String) list.get( i );
       String val = sysprops.getProperty( var );
@@ -259,8 +252,7 @@ public class EnvUtil {
    * variable is not defined and the default value is returned.
    */
   public static final String getSystemProperty( String key, String def ) {
-    String value = System.getProperty( key, def );
-    return value;
+    return System.getProperty( key, def );
   }
 
   /**

--- a/core/src/main/java/org/apache/hop/core/util/ExecutorUtil.java
+++ b/core/src/main/java/org/apache/hop/core/util/ExecutorUtil.java
@@ -32,6 +32,9 @@ public class ExecutorUtil {
   private static final AtomicInteger threadNum = new AtomicInteger( 1 );
   private static final ExecutorService executor = init();
 
+  private ExecutorUtil() {		 
+  }
+  
   private static ExecutorService init() {
     ExecutorService executorService = Executors.newCachedThreadPool( new ThreadFactory() {
       @Override public Thread newThread( Runnable r ) {

--- a/core/src/main/java/org/apache/hop/core/util/HttpClientUtil.java
+++ b/core/src/main/java/org/apache/hop/core/util/HttpClientUtil.java
@@ -49,6 +49,9 @@ import java.nio.charset.StandardCharsets;
  */
 public class HttpClientUtil {
 
+  private HttpClientUtil() {		 
+  }
+	  
   /**
    * @param response the httpresponse for processing
    * @return HttpEntity in String representation using "UTF-8" encoding

--- a/core/src/main/java/org/apache/hop/core/util/SocketUtil.java
+++ b/core/src/main/java/org/apache/hop/core/util/SocketUtil.java
@@ -30,6 +30,10 @@ import java.net.Socket;
  * Utility class for socket related methods
  */
 public class SocketUtil {
+	
+  private SocketUtil() {		 
+  }
+  
   /**
    * Attempts to connect to the specified host, wrapping any exceptions in a HopException
    *
@@ -39,8 +43,8 @@ public class SocketUtil {
    * @throws HopException
    */
   public static void connectToHost( String host, int port, int timeout ) throws HopException {
-    Socket socket = new Socket();
-    try {
+
+    try ( Socket socket = new Socket() ) {
       InetSocketAddress is = new InetSocketAddress( host, port );
       if ( timeout < 0 ) {
         socket.connect( is );
@@ -48,13 +52,7 @@ public class SocketUtil {
         socket.connect( is, timeout );
       }
     } catch ( Exception e ) {
-      throw new HopException( e );
-    } finally {
-      try {
-        socket.close();
-      } catch ( Exception e ) {
-        // Ignore
-      }
+      throw new HopException( e );    
     }
   }
 }

--- a/core/src/main/java/org/apache/hop/core/xml/XMLHandler.java
+++ b/core/src/main/java/org/apache/hop/core/xml/XMLHandler.java
@@ -86,6 +86,9 @@ public class XMLHandler {
   private static final SimpleDateFormat simpleDateFormat = new SimpleDateFormat( "yyyy/MM/dd HH:mm:ss.SSS" );
   private static final SimpleTimestampFormat simpleTimeStampFormat = new SimpleTimestampFormat( "yyyy/MM/dd HH:mm:ss.SSSSSSSSS" );
 
+  private XMLHandler() {
+  }
+  
   /**
    * The header string to specify encoding in UTF-8 for XML files
    *


### PR DESCRIPTION
[CLEANUP] Sonar cleanup of XMLHandler
* Added private constructor for this utility class

[CLEANUP] Sonar cleanup of EnvUtil
* Added a private constructor for this utility class
* Immediately return this expression instead of assigning it to the
temporary variable
* Change "try" to a try-with-resources

[CLEANUP] Sonar cleanup of ExecutorUtil
* Added a private constructor for this utility class

[CLEANUP] Sonar cleanup of SocketUtil
* Added a private constructor for this utility class
* Put the Socket variable inside a try-with-resources block

[CLEANUP] Sonar cleanup of HttpClientUtil
* Added a private constructor for this utility class

[CLEANUP] Sonar cleanup of HttpUtil
* Added private constructor for this utility class
* Replace charset name argument with StandardCharsets.UTF_8
* Change "try" to a try-with-resources

[CLEANUP] Sonar cleanup of Const
* Put single-quotes around ':' to use the faster "indexOf(char)" method.

[CLEANUP] Sonar cleanup of DBCache
* Change "try" to a try-with-resources
* Remove expression which always evaluates to "true"

[CLEANUP] Sonar cleanup of DBCacheEntry
* Remove this unnecessary null check; "instanceof" returns false for
nulls.
* Immediately return this expression instead of assigning it to the
temporary variable

[CLEANUP] Sonar cleanup of HopClientEnvironment
* Change "try" to a try-with-resources

[CLEANUP] Sonar cleanup of Props
* Change "try" to a try-with-resources
* Replace the type specification in this constructor call with the
diamond operator ("<>")
* Immediately return this expression instead of assigning it to the
temporary variable