### PR TITLE
add logn type support

### DIFF
--- a/plugins/databases/vertica/src/main/java/org/apache/hop/databases/vertica/VerticaDatabaseMeta.java
+++ b/plugins/databases/vertica/src/main/java/org/apache/hop/databases/vertica/VerticaDatabaseMeta.java
@@ -44,6 +44,14 @@ import org.apache.hop.core.row.IValueMeta;
 )
 @GuiPlugin( id = "GUI-VerticaDatabaseMeta" )
 public class VerticaDatabaseMeta extends BaseDatabaseMeta implements IDatabase {
+
+  /*
+   *
+   * https://www.vertica.com/docs/9.2.x/HTML/Content/Authoring/SQLReferenceManual/DataTypes/LongDataTypes.htm
+   *
+   * */
+  final int LONG = 65000;
+
   @Override
   public int[] getAccessTypeList() {
     return new int[] {
@@ -149,10 +157,22 @@ public class VerticaDatabaseMeta extends BaseDatabaseMeta implements IDatabase {
         retval += "INTEGER";
         break;
       case IValueMeta.TYPE_STRING:
-        retval += ( length < 1 ) ? "VARCHAR" : "VARCHAR(" + length + ")";
+        if (length < 1) {
+          retval += "VARCHAR";
+        } else if(length > LONG) {
+          retval += "LONG VARCHAR(" + length + ")";
+        } else {
+          retval += "VARCHAR(" + length + ")";
+        }
         break;
       case IValueMeta.TYPE_BINARY:
-        retval += ( length < 1 ) ? "VARBINARY" : "VARBINARY(" + length + ")";
+        if (length < 1) {
+          retval += "VARBINARY";
+        } else if(length > LONG) {
+          retval += "LONG VARBINARY(" + length + ")";
+        } else {
+          retval += "VARBINARY(" + length + ")";
+        }
         break;
       default:
         retval += " UNKNOWN";


### PR DESCRIPTION
it's no big change but is pain in the ass . 
Store data up to 32000000 octets.  supports two long data types:

-     LONG VARBINARY: Variable-length raw-byte data, such as spatial data. LONG VARBINARY values are not extended to the full width of the column.
-     LONG VARCHAR: Variable-length strings, such as log files and unstructured data. LONG VARCHAR values are not extended to the full width of the column.

Use LONG data types only when you need to store data greater than the maximum size of VARBINARY and VARCHAR data types (65 KB). Long data can include unstructured data, online comments or posts, or small log files.