### PR TITLE
On Windows 10, having the debug parameters in double quotes did not l…

### DIFF
--- a/assemblies/static/src/main/resources/hop-gui.bat
+++ b/assemblies/static/src/main/resources/hop-gui.bat
@@ -15,7 +15,7 @@ REM # Settings for all OSses
 if "%HOP_OPTIONS%"=="" set HOP_OPTIONS="-Xmx2048m"
 
 REM # optional line for attaching a debugger
-REM set HOP_OPTIONS=%HOP_OPTIONS% "-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005"
+REM set HOP_OPTIONS=%HOP_OPTIONS% -Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005
 
 REM Pass HOP variables if they're set.
 if not "%HOP_AUDIT_FOLDER%"=="" (

--- a/plugins/transforms/samplerows/src/main/java/org/apache/hop/pipeline/transforms/samplerows/SampleRows.java
+++ b/plugins/transforms/samplerows/src/main/java/org/apache/hop/pipeline/transforms/samplerows/SampleRows.java
@@ -46,9 +46,6 @@ import org.apache.hop.pipeline.transform.ITransform;
 public class SampleRows extends BaseTransform<SampleRowsMeta, SampleRowsData> implements ITransform<SampleRowsMeta, SampleRowsData> {
   private static Class<?> PKG = SampleRowsMeta.class; // for i18n purposes, needed by Translator!!
 
-  private SampleRowsMeta meta;
-  private SampleRowsData data;
-
   public SampleRows( TransformMeta transformMeta, SampleRowsMeta meta, SampleRowsData data, int copyNr, PipelineMeta pipelineMeta,
                      Pipeline pipeline ) {
     super( transformMeta, meta, data, copyNr, pipelineMeta, pipeline );


### PR DESCRIPTION
…et them work when running hop-gui.bat.  When removing the quotes, the parameters made it to java and the jdwp port 5005 was opened.