### PR TITLE
HOP-562 - Add bat files for Windows for the other utilities and improve the ones we have.

### DIFF
--- a/assemblies/static/src/main/resources/hop-conf.bat
+++ b/assemblies/static/src/main/resources/hop-conf.bat
@@ -1,0 +1,53 @@
+echo off
+setlocal
+set LIBSPATH=lib
+set SWTJAR=libswt\win64
+
+:NormalStart
+REM set java primary is HOP_JAVA_HOME fallback to JAVA_HOME or default java
+if not "%HOP_JAVA_HOME%"=="" (
+    set _HOP_JAVA="%HOP_JAVA_HOME%bin\java"
+) else if not "%JAVA_HOME%"=="" (
+    set _HOP_JAVA="%JAVA_HOME%bin\java"
+) else (
+    set _HOP_JAVA=java
+)
+
+REM # Settings for all OSses
+
+if "%HOP_OPTIONS%"=="" set HOP_OPTIONS=-Xmx2048m
+
+REM
+REM If the user passes in DEBUG as the first parameter, it starts Hop in debugger mode and opens port 5009
+REM to allow attaching a debugger to step code.
+if [%1]==[DEBUG] (
+REM # optional line for attaching a debugger
+set HOP_OPTIONS=%HOP_OPTIONS% -Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5009)
+
+REM Pass HOP variables if they're set.
+if not "%HOP_AUDIT_FOLDER%"=="" (
+  set HOP_OPTIONS=%HOP_OPTIONS% -DHOP_AUDIT_FOLDER=%HOP_AUDIT_FOLDER%
+)
+if not "%HOP_CONFIG_FOLDER%"=="" (
+  set HOP_OPTIONS=%HOP_OPTIONS% -DHOP_CONFIG_FOLDER=%HOP_CONFIG_FOLDER%
+)
+if not "%HOP_SHARED_JDBC_FOLDER%"=="" (
+  set HOP_OPTIONS=%HOP_OPTIONS% -DHOP_SHARED_JDBC_FOLDER=%HOP_SHARED_JDBC_FOLDER%
+)
+
+set HOP_OPTIONS=%HOP_OPTIONS% -DHOP_PLATFORM_OS=Windows
+set HOP_OPTIONS=%HOP_OPTIONS% -DHOP_PLATFORM_RUNTIME=GUI
+echo ===[Environment Settings - hop-gui.bat]===================================
+echo.
+echo Java identified as %_HOP_JAVA%
+echo.
+echo HOP_OPTIONS=%HOP_OPTIONS%
+echo.
+echo Command to start Hop will be:
+echo %_HOP_JAVA% -classpath %LIBSPATH%\*;%SWTJAR%\* -Djava.library.path=%LIBSPATH% %HOP_OPTIONS% org.apache.hop.config.HopConfig
+echo.
+echo ===[Starting HopConfig]=========================================================
+
+%_HOP_JAVA% -classpath %LIBSPATH%\*;%SWTJAR%\* -Djava.library.path=%LIBSPATH% %HOP_OPTIONS% org.apache.hop.config.HopConfig
+@echo off
+:End

--- a/assemblies/static/src/main/resources/hop-encrypt.bat
+++ b/assemblies/static/src/main/resources/hop-encrypt.bat
@@ -15,7 +15,7 @@ if not "%HOP_JAVA_HOME%"=="" (
 
 REM # Settings for all OSses
 
-if "%HOP_OPTIONS%"=="" set HOP_OPTIONS=-Xmx2048m
+if "%HOP_OPTIONS%"=="" set HOP_OPTIONS=-Xmx64m
 
 REM
 REM If the user passes in DEBUG as the first parameter, it starts Hop in debugger mode and opens port 5009
@@ -37,11 +37,12 @@ if not "%HOP_SHARED_JDBC_FOLDER%"=="" (
 
 set HOP_OPTIONS=%HOP_OPTIONS% -DHOP_PLATFORM_OS=Windows
 set HOP_OPTIONS=%HOP_OPTIONS% -DHOP_PLATFORM_RUNTIME=GUI
-echo ===[Environment Settings - hop-gui.bat]===================================
+echo ===[Environment Settings - hop-encrypt.bat]====================================
 echo.
 echo Java identified as %_HOP_JAVA%
 echo.
 echo HOP_OPTIONS=%HOP_OPTIONS%
+echo.
 echo.
 rem ===[Collect command line arguments...]======================================
 set _cmdline=
@@ -53,10 +54,10 @@ goto TopArg
 :EndArg
 
 echo Command to start Hop will be:
-echo %_HOP_JAVA% -classpath %LIBSPATH%\*;%SWTJAR%\* -Djava.library.path=%LIBSPATH% %HOP_OPTIONS% org.apache.hop.config.HopConfig %_cmdline%
+echo %_HOP_JAVA% -classpath %LIBSPATH%\*;%SWTJAR%\* -Djava.library.path=%LIBSPATH% %HOP_OPTIONS% org.apache.hop.core.encryption.Encr %_cmdline%
 echo.
-echo ===[Starting HopConfig]=========================================================
+echo ===[Starting HopEncrypt]=========================================================
 
-%_HOP_JAVA% -classpath %LIBSPATH%\*;%SWTJAR%\* -Djava.library.path=%LIBSPATH% %HOP_OPTIONS% org.apache.hop.config.HopConfig %_cmdline%
+%_HOP_JAVA% -classpath %LIBSPATH%\*;%SWTJAR%\* -Djava.library.path=%LIBSPATH% %HOP_OPTIONS% org.apache.hop.core.encryption.Encr %_cmdline%
 @echo off
 :End

--- a/assemblies/static/src/main/resources/hop-gui.bat
+++ b/assemblies/static/src/main/resources/hop-gui.bat
@@ -1,3 +1,4 @@
+setlocal
 set LIBSPATH=lib
 set SWTJAR=libswt\win64
 

--- a/assemblies/static/src/main/resources/hop-gui.bat
+++ b/assemblies/static/src/main/resources/hop-gui.bat
@@ -1,37 +1,71 @@
+echo off
 setlocal
 set LIBSPATH=lib
 set SWTJAR=libswt\win64
 
+set _temphelp=0
+if [%1]==[help] set _temphelp=1
+if [%1]==[Help] set _temphelp=1
+if %_temphelp%==1 (GOTO Help) ELSE (GOTO NormalStart)
+
+:Help
+echo ===[Hop Help - hop-gui.bat]===============================================
+echo Normally, no parameters are required to start Hop.  There is a debug mode
+echo that you can start by passing in DEBUG as the first parameter after hop-gui.bat
+echo.
+echo Example:
+echo   hop-gui.bat DEBUG
+echo
+echo The debug mode opens port 5005 locally when Hop starts allowing you to attaching
+echo a debugger from your favorite Java IDE tool and step code.
+echo ==========================================================================
+GOTO End
+
+:NormalStart
 REM set java primary is HOP_JAVA_HOME fallback to JAVA_HOME or default java
 if not "%HOP_JAVA_HOME%"=="" (
-    set _HOP_JAVA="%HOP_JAVA_HOME%\bin\java"
+    set _HOP_JAVA="%HOP_JAVA_HOME%bin\java"
 ) else if not "%JAVA_HOME%"=="" (
-    set _HOP_JAVA="%JAVA_HOME%\bin\java"
+    set _HOP_JAVA="%JAVA_HOME%bin\java"
 ) else (
-    set _HOP_JAVA="java"
+    set _HOP_JAVA=java
 )
 
 REM # Settings for all OSses
 
-if "%HOP_OPTIONS%"=="" set HOP_OPTIONS="-Xmx2048m"
+if "%HOP_OPTIONS%"=="" set HOP_OPTIONS=-Xmx2048m
 
+REM
+REM If the user passes in DEBUG as the first parameter, it starts Hop in debugger mode and opens port 5005
+REM to allow attaching a debugger to step code.
+if [%1]==[DEBUG] (
 REM # optional line for attaching a debugger
-REM set HOP_OPTIONS=%HOP_OPTIONS% -Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005
+set HOP_OPTIONS=%HOP_OPTIONS% -Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005)
 
 REM Pass HOP variables if they're set.
 if not "%HOP_AUDIT_FOLDER%"=="" (
-  set HOP_OPTIONS=%HOP_OPTIONS% "-DHOP_AUDIT_FOLDER="%HOP_AUDIT_FOLDER%
+  set HOP_OPTIONS=%HOP_OPTIONS% -DHOP_AUDIT_FOLDER=%HOP_AUDIT_FOLDER%
 )
 if not "%HOP_CONFIG_FOLDER%"=="" (
-  set HOP_OPTIONS=%HOP_OPTIONS% "-DHOP_CONFIG_FOLDER="%HOP_CONFIG_FOLDER%
+  set HOP_OPTIONS=%HOP_OPTIONS% -DHOP_CONFIG_FOLDER=%HOP_CONFIG_FOLDER%
 )
 if not "%HOP_SHARED_JDBC_FOLDER%"=="" (
-  set HOP_OPTIONS=%HOP_OPTIONS% "-DHOP_SHARED_JDBC_FOLDER="%HOP_SHARED_JDBC_FOLDER%
+  set HOP_OPTIONS=%HOP_OPTIONS% -DHOP_SHARED_JDBC_FOLDER=%HOP_SHARED_JDBC_FOLDER%
 )
 
-set HOP_OPTIONS=%HOP_OPTIONS% "-DHOP_PLATFORM_OS=Windows"
-set HOP_OPTIONS=%HOP_OPTIONS% "-DHOP_PLATFORM_RUNTIME=GUI"
+set HOP_OPTIONS=%HOP_OPTIONS% -DHOP_PLATFORM_OS=Windows
+set HOP_OPTIONS=%HOP_OPTIONS% -DHOP_PLATFORM_RUNTIME=GUI
+echo ===[Environment Settings - hop-gui.bat]===================================
+echo.
+echo Java identified as %_HOP_JAVA%
+echo.
+echo HOP_OPTIONS=%HOP_OPTIONS%
+echo.
+echo Command to start Hop will be:
+echo %_HOP_JAVA% -classpath %LIBSPATH%\*;%SWTJAR%\* -Djava.library.path=%LIBSPATH% %HOP_OPTIONS% org.apache.hop.ui.hopgui.HopGui
+echo.
+echo ===[Starting Hop]=========================================================
 
-@echo on
-%_HOP_JAVA% -classpath %LIBSPATH%\*;%SWTJAR%\* "-Djava.library.path=%LIBSPATH%" %HOP_OPTIONS% org.apache.hop.ui.hopgui.HopGui
+%_HOP_JAVA% -classpath %LIBSPATH%\*;%SWTJAR%\* -Djava.library.path=%LIBSPATH% %HOP_OPTIONS% org.apache.hop.ui.hopgui.HopGui
 @echo off
+:End

--- a/assemblies/static/src/main/resources/hop-run.bat
+++ b/assemblies/static/src/main/resources/hop-run.bat
@@ -1,4 +1,4 @@
-
+setlocal
 set LIBSPATH=lib
 set SWTJAR=libswt\win64
 

--- a/assemblies/static/src/main/resources/hop-run.bat
+++ b/assemblies/static/src/main/resources/hop-run.bat
@@ -10,25 +10,6 @@ if %_temphelp%==1 (GOTO Help) ELSE (GOTO NormalStart)
 
 :Help
 echo ===[HopRun - hop-run.bat]=================================================
-echo Usage: ^<main class^> [-ho] [-e=^<environment^>] [-f=^<filename^>] [-j=^<project^>]
-echo                     [-l=^<level^>] [-r=^<runConfigurationName^>] [-p=^<parameters^>[,
-echo                     ^<parameters^>...]]... [-s=^<systemProperties^>[,
-echo                     ^<systemProperties^>...]]...
-echo   -e, --environment=^<environment^>
-echo                             The name of the lifecycle environment to use
-echo   -f, --file=^<filename^>     The filename of the workflow or pipeline to run
-echo   -h, --help                Displays this help message and quits.
-echo   -j, --project=^<project^>   The name of the project to use
-echo   -l, --level=^<level^>       The debug level, one of NONE, MINIMAL, BASIC, DETAILED,
-echo                               DEBUG, ROWLEVEL
-echo   -o, --printoptions        Print the used options
-echo   -p, --parameters=^<parameters^>[,^<parameters^>...]
-echo                             A comma separated list of PARAMETER=VALUE pairs
-echo   -r, --runconfig=^<runConfigurationName^>
-echo                             The name of the Run Configuration to use
-echo   -s, --system-properties=^<systemProperties^>[,^<systemProperties^>...]
-echo                             A comma separated list of KEY=VALUE pairs
-echo.
 echo.
 echo Example:
 echo   hop-run.bat --file=C:\Users\usbra\Desktop\converted_financial_metrics\update_dashboard_financials.hwf --environment=converted_financial_metrics --project=converted_financial_metrics --runconfig=local

--- a/assemblies/static/src/main/resources/hop-server.bat
+++ b/assemblies/static/src/main/resources/hop-server.bat
@@ -1,0 +1,63 @@
+echo off
+setlocal
+set LIBSPATH=lib
+set SWTJAR=libswt\win64
+
+:NormalStart
+REM set java primary is HOP_JAVA_HOME fallback to JAVA_HOME or default java
+if not "%HOP_JAVA_HOME%"=="" (
+    set _HOP_JAVA="%HOP_JAVA_HOME%bin\java"
+) else if not "%JAVA_HOME%"=="" (
+    set _HOP_JAVA="%JAVA_HOME%bin\java"
+) else (
+    set _HOP_JAVA=java
+)
+
+REM # Settings for all OSses
+
+if "%HOP_OPTIONS%"=="" set HOP_OPTIONS=-Xmx2048m
+
+REM
+REM If the user passes in DEBUG as the first parameter, it starts Hop in debugger mode and opens port 5009
+REM to allow attaching a debugger to step code.
+if [%1]==[DEBUG] (
+REM # optional line for attaching a debugger
+set HOP_OPTIONS=%HOP_OPTIONS% -Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5009)
+
+REM Pass HOP variables if they're set.
+if not "%HOP_AUDIT_FOLDER%"=="" (
+  set HOP_OPTIONS=%HOP_OPTIONS% -DHOP_AUDIT_FOLDER=%HOP_AUDIT_FOLDER%
+)
+if not "%HOP_CONFIG_FOLDER%"=="" (
+  set HOP_OPTIONS=%HOP_OPTIONS% -DHOP_CONFIG_FOLDER=%HOP_CONFIG_FOLDER%
+)
+if not "%HOP_SHARED_JDBC_FOLDER%"=="" (
+  set HOP_OPTIONS=%HOP_OPTIONS% -DHOP_SHARED_JDBC_FOLDER=%HOP_SHARED_JDBC_FOLDER%
+)
+
+set HOP_OPTIONS=%HOP_OPTIONS% -DHOP_PLATFORM_OS=Windows
+set HOP_OPTIONS=%HOP_OPTIONS% -DHOP_PLATFORM_RUNTIME=GUI
+echo ===[Environment Settings - hop-server.bat]====================================
+echo.
+echo Java identified as %_HOP_JAVA%
+echo.
+echo HOP_OPTIONS=%HOP_OPTIONS%
+echo.
+echo.
+rem ===[Collect command line arguments...]======================================
+set _cmdline=
+:TopArg
+if %1!==! goto EndArg
+set _cmdline=%_cmdline% %1
+shift
+goto TopArg
+:EndArg
+
+echo Command to start Hop will be:
+echo %_HOP_JAVA% -classpath %LIBSPATH%\*;%SWTJAR%\* -Djava.library.path=%LIBSPATH% %HOP_OPTIONS% org.apache.hop.www.HopServer %_cmdline%
+echo.
+echo ===[Starting HopServer]=========================================================
+
+%_HOP_JAVA% -classpath %LIBSPATH%\*;%SWTJAR%\* -Djava.library.path=%LIBSPATH% %HOP_OPTIONS% org.apache.hop.www.HopServer %_cmdline%
+@echo off
+:End

--- a/assemblies/static/src/main/resources/hop-translator.bat
+++ b/assemblies/static/src/main/resources/hop-translator.bat
@@ -1,0 +1,63 @@
+echo off
+setlocal
+set LIBSPATH=lib
+set SWTJAR=libswt\win64
+
+:NormalStart
+REM set java primary is HOP_JAVA_HOME fallback to JAVA_HOME or default java
+if not "%HOP_JAVA_HOME%"=="" (
+    set _HOP_JAVA="%HOP_JAVA_HOME%bin\java"
+) else if not "%JAVA_HOME%"=="" (
+    set _HOP_JAVA="%JAVA_HOME%bin\java"
+) else (
+    set _HOP_JAVA=java
+)
+
+REM # Settings for all OSses
+
+if "%HOP_OPTIONS%"=="" set HOP_OPTIONS=-Xmx2048m
+
+REM
+REM If the user passes in DEBUG as the first parameter, it starts Hop in debugger mode and opens port 5009
+REM to allow attaching a debugger to step code.
+if [%1]==[DEBUG] (
+REM # optional line for attaching a debugger
+set HOP_OPTIONS=%HOP_OPTIONS% -Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5009)
+
+REM Pass HOP variables if they're set.
+if not "%HOP_AUDIT_FOLDER%"=="" (
+  set HOP_OPTIONS=%HOP_OPTIONS% -DHOP_AUDIT_FOLDER=%HOP_AUDIT_FOLDER%
+)
+if not "%HOP_CONFIG_FOLDER%"=="" (
+  set HOP_OPTIONS=%HOP_OPTIONS% -DHOP_CONFIG_FOLDER=%HOP_CONFIG_FOLDER%
+)
+if not "%HOP_SHARED_JDBC_FOLDER%"=="" (
+  set HOP_OPTIONS=%HOP_OPTIONS% -DHOP_SHARED_JDBC_FOLDER=%HOP_SHARED_JDBC_FOLDER%
+)
+
+set HOP_OPTIONS=%HOP_OPTIONS% -DHOP_PLATFORM_OS=Windows
+set HOP_OPTIONS=%HOP_OPTIONS% -DHOP_PLATFORM_RUNTIME=GUI
+echo ===[Environment Settings - hop-translator.bat]=============================
+echo.
+echo Java identified as %_HOP_JAVA%
+echo.
+echo HOP_OPTIONS=%HOP_OPTIONS%
+echo.
+echo.
+rem ===[Collect command line arguments...]======================================
+set _cmdline=
+:TopArg
+if %1!==! goto EndArg
+set _cmdline=%_cmdline% %1
+shift
+goto TopArg
+:EndArg
+
+echo Command to start Hop will be:
+echo %_HOP_JAVA% -classpath %LIBSPATH%\*;%SWTJAR%\* -Djava.library.path=%LIBSPATH% %HOP_OPTIONS% org.apache.hop.ui.i18n.editor.Translator %_cmdline%
+echo.
+echo ===[Starting Hop Translator]=========================================================
+
+%_HOP_JAVA% -classpath %LIBSPATH%\*;%SWTJAR%\* -Djava.library.path=%LIBSPATH% %HOP_OPTIONS% org.apache.hop.ui.i18n.editor.Translator %_cmdline%
+@echo off
+:End


### PR DESCRIPTION
[HOP-562]  **hop-run.bat** was broken on Windows.  It is now fixed to parse command line arguments correctly and pass them into the java application.  There is now a 'help' parameter that outputs a screen for both hop-gui.bat and hop-run.bat that instructs the user on how to use the software and there is a real live example for hop-run.bat which takes a lot of parameters.

[HOP-562]: https://project-hop.atlassian.net/browse/HOP-562