### PR TITLE
checkstyle plugin added within code-quality profile

### DIFF
--- a/assemblies/plugins/engines/beam/pom.xml
+++ b/assemblies/plugins/engines/beam/pom.xml
@@ -36,8 +36,6 @@
     <apache-beam-version>2.24.0</apache-beam-version>
     <spark-version>2.4.6</spark-version>
     <flink-version>1.9.3</flink-version>
-
-    <junit.version>4.4</junit.version>
     <json-simple.version>1.1.1</json-simple.version>
   </properties>
 

--- a/assemblies/plugins/vfs/s3/pom.xml
+++ b/assemblies/plugins/vfs/s3/pom.xml
@@ -24,7 +24,6 @@
         <guava.version>19.0</guava.version>
 
         <!-- Test dependencies -->
-        <junit.version>4.12</junit.version>
         <mockito.version>1.10.19</mockito.version>
         <powermock.version>1.7.4</powermock.version>
         <aws-java-sdk-s3.version>1.11.516</aws-java-sdk-s3.version>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -543,7 +543,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>${junit.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/plugins/engines/beam/pom.xml
+++ b/plugins/engines/beam/pom.xml
@@ -35,8 +35,6 @@
     <apache-beam-version>2.24.0</apache-beam-version>
     <spark-version>2.4.6</spark-version>
     <flink-version>1.9.3</flink-version>
-
-    <junit.version>4.4</junit.version>
     <json-simple.version>1.1.1</json-simple.version>
   </properties>
 

--- a/plugins/transforms/kafka/pom.xml
+++ b/plugins/transforms/kafka/pom.xml
@@ -16,8 +16,6 @@
 
   <properties>
     <kafka-clients.version>0.10.2.1</kafka-clients.version>
-
-    <junit.version>4.4</junit.version>
     <mockito-all.version>1.9.5</mockito-all.version>
     <dependency.mockito.revision>1.10.19</dependency.mockito.revision>
     <dependency.hamcrest.revision>1.3</dependency.hamcrest.revision>

--- a/plugins/vfs/s3/pom.xml
+++ b/plugins/vfs/s3/pom.xml
@@ -23,7 +23,6 @@
     <guava.version>19.0</guava.version>
 
     <!-- Test dependencies -->
-    <junit.version>4.12</junit.version>
     <mockito.version>1.10.19</mockito.version>
     <powermock.version>1.7.4</powermock.version>
     <aws-java-sdk-s3.version>1.11.516</aws-java-sdk-s3.version>

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
         <powermock-module-junit4.version>1.7.3</powermock-module-junit4.version>
         <powermock-api-mockito.version>1.7.3</powermock-api-mockito.version>
         <java-hamcrest.version>2.0.0.0</java-hamcrest.version>
-        <junit.version>4.12</junit.version>
+        <junit.version>4.13.1</junit.version>
 
         <!-- Copy from master POM (NEEDS CLEANUP) -->
         <!-- VERSIONS -->
@@ -182,7 +182,6 @@
         <!-- Documentation properties -->
         <!-- parsedVersion.* properties are dynamically created by the build-helper-maven-plugin:create-doc-version-property -->
 
-        <junit.version>4.11</junit.version>
 
         <!-- http://maven.apache.org/surefire/maven-surefire-plugin/examples/fork-options-and-parallel-execution.html -->
         <maven-surefire-plugin.reuseForks>true

--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,7 @@
         <sonar-maven-plugin.version>3.5.0.1254</sonar-maven-plugin.version>
         <maven-bundle-plugin.version>2.5.3</maven-bundle-plugin.version>
         <karaf-maven-plugin.version>3.0.8</karaf-maven-plugin.version>
+        <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
         <spotless-maven-plugin.version>2.4.2</spotless-maven-plugin.version>
 
         <codehaus-jackson.version>1.9.13</codehaus-jackson.version>
@@ -582,6 +583,10 @@
                     <version>${maven-assembly-plugin.version}</version>
                 </plugin>
                 <plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-checkstyle-plugin</artifactId>
+				</plugin>
+                <plugin>
 				<groupId>com.diffplug.spotless</groupId>
 				<artifactId>spotless-maven-plugin</artifactId>
 				<version>${spotless-maven-plugin.version}</version>
@@ -961,6 +966,35 @@
                 </dependencies>
             </dependencyManagement>
         </profile>
+        <profile>
+			<id>code-quality</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-checkstyle-plugin</artifactId>
+						<version>${maven-checkstyle-plugin.version}</version>
+						<executions>
+							<execution>
+								<id>validate</id>
+								<goals>
+									<goal>check</goal>
+								</goals>
+								<phase>validate</phase>
+								<configuration>
+									<configLocation>google_checks.xml</configLocation>
+									<encoding>UTF-8</encoding>
+									<failOnViolation>true</failOnViolation>
+									<violationSeverity>warning</violationSeverity>
+									<includeResources>false</includeResources>
+									<includeTestSourceDirectory>false</includeTestSourceDirectory>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
     </profiles>
 
     <reporting>


### PR DESCRIPTION
This PR adds checkstyle plugin. To avoid failing CI/CD and not to block other developers it is added in profile called code-quality. 

**What is the purpose:**
To enforce standard coding style across developers using different IDE.
To have only intended change in PR (Avoiding whitespace changes)
To save time in reviewing and gain confident in PR.

This profile is to enforce code quality check. At the time of introducing this profile,
we will not able to use these checks and enforcement at CI/CD (Jenkins). 
			
**When this profile used:**
        To begin with this profile can be activated explicitly using `mvn -Pcode-quality` by developers.
        We can resolve the checkstyle issues module by module as and when we work. 

To begin with, we can run following command to format to resolve lot of formatting issues which are reported by checkstyle.
```
 mvn net.revelc.code.formatter:formatter-maven-plugin:2.13.0:format
```
Leaving this command to the project maintainers as it bring lots of changes which is harder to review or confidently accept the PR. I would recommend formatting module by module or even smaller scope without making any business logic changes and creating merge conflicts on existing branches.

**Challenge:**
Developers finds it hard to adopt at the beginning. We need to write some tip in README.md as we learn the trick. We may need to suppress some checkstyle rules.

**Target:**
Enable checkstyle as part of CI/CD PR checks.