### PR TITLE
HOP-2087 - Added the feature of holding CTRL and clicking on a hop to…

### DIFF
--- a/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/HopGuiPipelineGraph.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/HopGuiPipelineGraph.java
@@ -751,11 +751,19 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
             break;
         }
       } else {
+        // hop links between steps are found searching by (x,y) coordinates.
         PipelineHopMeta hop = findPipelineHop( real.x, real.y );
         if ( hop != null ) {
-          // A hop: show context dialog in mouseUp()
+          // User held control and clicked a hop between steps - We want to flip the active state of the hop.
           //
-          clickedPipelineHop = hop;
+          if ( e.button == 2 || ( e.button == 1 && control ) ) {
+            hop.setEnabled(!hop.isEnabled());
+            updateGui();
+          } else {
+            // A hop: show context dialog in mouseUp()
+            //
+            clickedPipelineHop = hop;
+          }
         } else {
           // No area-owner & no hop means : background click:
           //

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/file/workflow/HopGuiWorkflowGraph.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/file/workflow/HopGuiWorkflowGraph.java
@@ -602,10 +602,16 @@ public class HopGuiWorkflowGraph extends HopGuiAbstractGraph
       } else {
         WorkflowHopMeta hop = findWorkflowHop( real.x, real.y );
         if ( hop != null ) {
-          // A hop: show the hop context menu in the mouseUp() listener
+          // User held control and clicked a hop between steps - We want to flip the active state of the hop.
           //
-          clickedWorkflowHop = hop;
-
+          if ( e.button == 2 || ( e.button == 1 && control ) ) {
+            hop.setEnabled(!hop.isEnabled());
+            updateGui();
+          } else {
+            // A hop: show the hop context menu in the mouseUp() listener
+            //
+            clickedWorkflowHop = hop;
+          }
         } else {
           // No area-owner means: background:
           //


### PR DESCRIPTION
… enable / disable it quickly instead of going through a menu to do it.  Reduces clicks from 2 down to 1.  This works in both workflows and pipelines.