### PR TITLE
Fix for POM warnings appeared in eclipse IDE

### DIFF
--- a/assemblies/plugins/transforms/ldifinput/pom.xml
+++ b/assemblies/plugins/transforms/ldifinput/pom.xml
@@ -12,7 +12,6 @@
 
 
     <artifactId>hop-assemblies-plugins-transforms-ldifinput</artifactId>
-    <version>0.40-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Hop Assemblies Plugins Transforms LDIF Input</name>

--- a/plugins/transforms/ldap/pom.xml
+++ b/plugins/transforms/ldap/pom.xml
@@ -19,13 +19,11 @@
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
-            <version>${powermock-module-junit4.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito</artifactId>
-            <version>${powermock-api-mockito.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Removed unwanted tags which are showing as warnings.

**Warning Messages:**
Overriding managed version 1.7.3 for powermock-module-junit4
Version is duplicate of parent version

**Reference:**
https://www.yawintutor.com/warning-duplicating-managed-version-maven/
https://stackoverflow.com/questions/3428685/maven-duplicated-groupid-artifactid-and-versions-in-submodules

Action Item:
Need to find 
- Is this something worth fixing? What does Apache Maven doc says?
- Is it just eclipse plugin (m2e) consider that as problem/warning? What about other IDE?
- Will this change break maven-release-plugin?
