### PR TITLE
HOP-2122 Cleanup action variable

### DIFF
--- a/engine/src/main/java/org/apache/hop/workflow/action/IActionDialog.java
+++ b/engine/src/main/java/org/apache/hop/workflow/action/IActionDialog.java
@@ -55,14 +55,14 @@ import org.apache.hop.metadata.api.IHopMetadataProvider;
 public interface IActionDialog {
 
   /**
-   * Opens a JobEntryDialog and waits for the dialog to be confirmed or cancelled.
+   * Opens a ActionDialog and waits for the dialog to be confirmed or cancelled.
    *
    * @return the action interface if the dialog is confirmed, null otherwise
    */
   IAction open();
 
   /**
-   * The MetaStore to pass
+   * The Metadata provider to pass
    *
    * @param metadataProvider
    */

--- a/plugins/actions/abort/src/main/java/org/apache/hop/workflow/actions/abort/ActionAbortDialog.java
+++ b/plugins/actions/abort/src/main/java/org/apache/hop/workflow/actions/abort/ActionAbortDialog.java
@@ -60,6 +60,8 @@ import org.eclipse.swt.widgets.Text;
 public class ActionAbortDialog extends ActionDialog implements IActionDialog {
   private static final Class<?> PKG = ActionAbortDialog.class; // for i18n purposes, needed by Translator!!
 
+  private Shell shell;
+  
   private ActionAbort action;
 
   private boolean changed;
@@ -69,7 +71,7 @@ public class ActionAbortDialog extends ActionDialog implements IActionDialog {
   private TextVar wMessageAbort;
 
   public ActionAbortDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionAbort) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "ActionAbortDialog.Jobname.Label" ) );
@@ -126,7 +128,7 @@ public class ActionAbortDialog extends ActionDialog implements IActionDialog {
     fdlMessageAbort.top = new FormAttachment( wName, margin );
     wlMessageAbort.setLayoutData( fdlMessageAbort );
 
-    wMessageAbort = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wMessageAbort = new TextVar( this.getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wMessageAbort );
     wMessageAbort.setToolTipText( BaseMessages.getString( PKG, "ActionAbortDialog.MessageAbort.Tooltip" ) );
     wMessageAbort.addModifyListener( lsMod );

--- a/plugins/actions/checkdbconnection/src/main/java/org/apache/hop/workflow/actions/checkdbconnection/ActionCheckDbConnectionsDialog.java
+++ b/plugins/actions/checkdbconnection/src/main/java/org/apache/hop/workflow/actions/checkdbconnection/ActionCheckDbConnectionsDialog.java
@@ -65,7 +65,8 @@ import java.util.List;
 public class ActionCheckDbConnectionsDialog extends ActionDialog implements IActionDialog {
   private static final Class<?> PKG = ActionCheckDbConnectionsDialog.class; // for i18n purposes, needed by Translator!!
 
-
+  private Shell shell;
+  
   private Text wName;
 
   private ActionCheckDbConnections action;
@@ -75,7 +76,7 @@ public class ActionCheckDbConnectionsDialog extends ActionDialog implements IAct
   private TableView wFields;
 
   public ActionCheckDbConnectionsDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionCheckDbConnections) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "ActionCheckDbConnections.Name.Default" ) );
@@ -162,7 +163,7 @@ public class ActionCheckDbConnectionsDialog extends ActionDialog implements IAct
       new ColumnInfo[] {
         new ColumnInfo(
           BaseMessages.getString( PKG, "ActionCheckDbConnections.Fields.Argument.Label" ),
-          ColumnInfo.COLUMN_TYPE_CCOMBO, workflowMeta.getDatabaseNames(), false ),
+          ColumnInfo.COLUMN_TYPE_CCOMBO, this.getWorkflowMeta().getDatabaseNames(), false ),
         new ColumnInfo(
           BaseMessages.getString( PKG, "ActionCheckDbConnections.Fields.WaitFor.Label" ),
           ColumnInfo.COLUMN_TYPE_TEXT, false ),
@@ -176,7 +177,7 @@ public class ActionCheckDbConnectionsDialog extends ActionDialog implements IAct
 
     wFields =
       new TableView(
-        workflowMeta, shell, SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI, colinf, FieldsRows, lsMod, props );
+    		  this.getWorkflowMeta(), shell, SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI, colinf, FieldsRows, lsMod, props );
 
     FormData fdFields = new FormData();
     fdFields.left = new FormAttachment( 0, 0 );
@@ -258,7 +259,7 @@ public class ActionCheckDbConnectionsDialog extends ActionDialog implements IAct
 
   public void getDatabases() {
     wFields.removeAll();
-    List<DatabaseMeta> databases = workflowMeta.getDatabases();
+    List<DatabaseMeta> databases = this.getWorkflowMeta().getDatabases();
     for (DatabaseMeta ci : databases) {
       if (ci != null) {
         wFields.add(new String[]{ci.getName(), "0", ActionCheckDbConnections.unitTimeDesc[0]});
@@ -324,7 +325,7 @@ public class ActionCheckDbConnectionsDialog extends ActionDialog implements IAct
 
     for ( int i = 0; i < nritems; i++ ) {
       String arg = wFields.getNonEmpty( i ).getText( 1 );
-      DatabaseMeta dbMeta = workflowMeta.findDatabase( arg );
+      DatabaseMeta dbMeta = this.getWorkflowMeta().findDatabase( arg );
       if ( dbMeta != null ) {
         connections[ i ] = dbMeta;
         waitfors[ i ] = "" + Const.toInt( wFields.getNonEmpty( i ).getText( 2 ), 0 );

--- a/plugins/actions/checkfilelocked/src/main/java/org/apache/hop/workflow/actions/checkfilelocked/ActionCheckFilesLockedDialog.java
+++ b/plugins/actions/checkfilelocked/src/main/java/org/apache/hop/workflow/actions/checkfilelocked/ActionCheckFilesLockedDialog.java
@@ -82,7 +82,7 @@ public class ActionCheckFilesLockedDialog extends ActionDialog implements IActio
 
   public ActionCheckFilesLockedDialog( Shell parent, IAction action,
                                        WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionCheckFilesLocked) action;
 
     if ( this.action.getName() == null ) {
@@ -218,7 +218,7 @@ public class ActionCheckFilesLockedDialog extends ActionDialog implements IActio
     fdbDirectory.top = new FormAttachment(wSettings, margin );
     wbDirectory.setLayoutData(fdbDirectory);
 
-    wbDirectory.addListener( SWT.Selection, e -> BaseDialog.presentDirectoryDialog( shell, wFilename, workflowMeta ));
+    wbDirectory.addListener( SWT.Selection, e -> BaseDialog.presentDirectoryDialog( shell, wFilename, getWorkflowMeta() ));
 
     wbFilename = new Button( shell, SWT.PUSH | SWT.CENTER );
     props.setLook( wbFilename );
@@ -237,7 +237,7 @@ public class ActionCheckFilesLockedDialog extends ActionDialog implements IActio
     fdbaFilename.top = new FormAttachment(wSettings, margin );
     wbaFilename.setLayoutData(fdbaFilename);
 
-    wFilename = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wFilename = new TextVar( this.getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wFilename );
     wFilename.addModifyListener( lsMod );
     FormData fdFilename = new FormData();
@@ -247,9 +247,9 @@ public class ActionCheckFilesLockedDialog extends ActionDialog implements IActio
     wFilename.setLayoutData(fdFilename);
 
     // Whenever something changes, set the tooltip to the expanded version:
-    wFilename.addModifyListener( e -> wFilename.setToolTipText( workflowMeta.environmentSubstitute( wFilename.getText() ) ) );
+    wFilename.addModifyListener( e -> wFilename.setToolTipText( this.getWorkflowMeta().environmentSubstitute( wFilename.getText() ) ) );
 
-    wbFilename.addListener( SWT.Selection, e-> BaseDialog.presentFileDialog(shell, wFilename, workflowMeta,
+    wbFilename.addListener( SWT.Selection, e-> BaseDialog.presentFileDialog(shell, wFilename, getWorkflowMeta(),
       new String[] { "*" }, FILETYPES, true)
     );
 
@@ -263,7 +263,7 @@ public class ActionCheckFilesLockedDialog extends ActionDialog implements IActio
     fdlFilemask.right = new FormAttachment( middle, -margin );
     wlFilemask.setLayoutData(fdlFilemask);
     wFilemask =
-      new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
+      new TextVar( this.getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
         PKG, "JobCheckFilesLocked.Wildcard.Tooltip" ) );
     props.setLook( wFilemask );
     wFilemask.addModifyListener( lsMod );
@@ -321,7 +321,7 @@ public class ActionCheckFilesLockedDialog extends ActionDialog implements IActio
 
     wFields =
       new TableView(
-        workflowMeta, shell, SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI, colinf, FieldsRows, lsMod, props );
+    		  this.getWorkflowMeta(), shell, SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI, colinf, FieldsRows, lsMod, props );
 
     FormData fdFields = new FormData();
     fdFields.left = new FormAttachment( 0, 0 );

--- a/plugins/actions/columnsexist/src/main/java/org/apache/hop/workflow/actions/columnsexist/ActionColumnsExistDialog.java
+++ b/plugins/actions/columnsexist/src/main/java/org/apache/hop/workflow/actions/columnsexist/ActionColumnsExistDialog.java
@@ -89,7 +89,7 @@ public class ActionColumnsExistDialog extends ActionDialog implements IActionDia
   private TextVar wSchemaname;
 
   public ActionColumnsExistDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionColumnsExist) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "ActionColumnsExist.Name.Default" ) );
@@ -163,7 +163,7 @@ public class ActionColumnsExistDialog extends ActionDialog implements IActionDia
       }
     } );
 
-    wSchemaname = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wSchemaname = new TextVar( this.getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wSchemaname );
     wSchemaname.setToolTipText( BaseMessages.getString( PKG, "ActionColumnsExist.Schemaname.Tooltip" ) );
     wSchemaname.addModifyListener( lsMod );
@@ -197,7 +197,7 @@ public class ActionColumnsExistDialog extends ActionDialog implements IActionDia
     } );
 
     // Table name
-    wTablename = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wTablename = new TextVar( this.getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wTablename );
     wTablename.addModifyListener( lsMod );
     FormData fdTablename = new FormData();
@@ -249,8 +249,7 @@ public class ActionColumnsExistDialog extends ActionDialog implements IActionDia
     colinf[ 0 ].setToolTip( BaseMessages.getString( PKG, "ActionColumnsExist.Fields.Column" ) );
 
     wFields =
-      new TableView(
-        workflowMeta, shell, SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI, colinf, FieldsRows, lsMod, props );
+      new TableView(getWorkflowMeta(), shell, SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI, colinf, FieldsRows, lsMod, props );
 
     FormData fdFields = new FormData();
     fdFields.left = new FormAttachment( 0, 0 );
@@ -335,9 +334,9 @@ public class ActionColumnsExistDialog extends ActionDialog implements IActionDia
   private void getTableName() {
     String databaseName = wConnection.getText();
     if ( StringUtils.isNotEmpty( databaseName ) ) {
-      DatabaseMeta databaseMeta = workflowMeta.findDatabase( databaseName );
+      DatabaseMeta databaseMeta = this.getWorkflowMeta().findDatabase( databaseName );
       if ( databaseMeta != null ) {
-        DatabaseExplorerDialog std = new DatabaseExplorerDialog( shell, SWT.NONE, databaseMeta, workflowMeta.getDatabases() );
+        DatabaseExplorerDialog std = new DatabaseExplorerDialog( shell, SWT.NONE, databaseMeta, this.getWorkflowMeta().getDatabases() );
         std.setSelectedSchemaAndTable( wSchemaname.getText(), wTablename.getText() );
         if ( std.open() ) {
           wSchemaname.setText( Const.NVL( std.getSchemaName(), "" ) );
@@ -401,7 +400,7 @@ public class ActionColumnsExistDialog extends ActionDialog implements IActionDia
       return;
     }
     action.setName( wName.getText() );
-    action.setDatabase( workflowMeta.findDatabase( wConnection.getText() ) );
+    action.setDatabase( getWorkflowMeta().findDatabase( wConnection.getText() ) );
     action.setTablename( wTablename.getText() );
     action.setSchemaname( wSchemaname.getText() );
 
@@ -432,16 +431,16 @@ public class ActionColumnsExistDialog extends ActionDialog implements IActionDia
    */
   private void getListColumns() {
     if ( !Utils.isEmpty( wTablename.getText() ) ) {
-      DatabaseMeta databaseMeta = workflowMeta.findDatabase( wConnection.getText() );
+      DatabaseMeta databaseMeta = getWorkflowMeta().findDatabase( wConnection.getText() );
       if ( databaseMeta != null ) {
         Database database = new Database( loggingObject, databaseMeta );
-        database.shareVariablesWith( workflowMeta );
+        database.shareVariablesWith( getWorkflowMeta() );
         try {
           database.connect();
           IRowMeta row =
             database.getTableFieldsMeta(
-              workflowMeta.environmentSubstitute( wSchemaname.getText() ),
-              workflowMeta.environmentSubstitute( wTablename.getText() ) );
+            		getWorkflowMeta().environmentSubstitute( wSchemaname.getText() ),
+              getWorkflowMeta().environmentSubstitute( wTablename.getText() ) );
           if ( row != null ) {
             String[] available = row.getFieldNames();
 
@@ -471,10 +470,10 @@ public class ActionColumnsExistDialog extends ActionDialog implements IActionDia
     if ( wSchemaname.isDisposed() ) {
       return;
     }
-    DatabaseMeta databaseMeta = workflowMeta.findDatabase( wConnection.getText() );
+    DatabaseMeta databaseMeta = getWorkflowMeta().findDatabase( wConnection.getText() );
     if ( databaseMeta != null ) {
       Database database = new Database( loggingObject, databaseMeta );
-      database.shareVariablesWith( workflowMeta );
+      database.shareVariablesWith( getWorkflowMeta() );
       try {
         database.connect();
         String[] schemas = database.getSchemas();

--- a/plugins/actions/columnsexist/src/test/java/org/apache/hop/workflow/actions/columnsexist/WorkflowActionColumnsExistTest.java
+++ b/plugins/actions/columnsexist/src/test/java/org/apache/hop/workflow/actions/columnsexist/WorkflowActionColumnsExistTest.java
@@ -60,7 +60,7 @@ import static org.mockito.Mockito.when;
  * @since 21-03-2017
  */
 
-public class WorkflowEntryColumnsExistTest {
+public class WorkflowActionColumnsExistTest {
   @ClassRule public static RestoreHopEngineEnvironment env = new RestoreHopEngineEnvironment();
 
   private static final String TABLENAME = "TABLE";

--- a/plugins/actions/copyfiles/src/main/java/org/apache/hop/workflow/actions/copyfiles/ActionCopyFilesDialog.java
+++ b/plugins/actions/copyfiles/src/main/java/org/apache/hop/workflow/actions/copyfiles/ActionCopyFilesDialog.java
@@ -106,7 +106,7 @@ public class ActionCopyFilesDialog extends ActionDialog implements IActionDialog
   private ToolItem deleteToolItem; // Delete
 
   public ActionCopyFilesDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionCopyFiles) action;
 
     if ( this.action.getName() == null ) {
@@ -352,7 +352,7 @@ public class ActionCopyFilesDialog extends ActionDialog implements IActionDialog
 
     wFields =
       new TableView(
-        workflowMeta, wFilesComp, SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI, colinf, FieldsRows, lsMod, props );
+        getWorkflowMeta(), wFilesComp, SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI, colinf, FieldsRows, lsMod, props );
 
     FormData fdFields = new FormData();
     fdFields.left = new FormAttachment( 0, margin );

--- a/plugins/actions/copyfiles/src/test/java/org/apache/hop/workflow/actions/copyfiles/WorkflowActionCopyFilesTest.java
+++ b/plugins/actions/copyfiles/src/test/java/org/apache/hop/workflow/actions/copyfiles/WorkflowActionCopyFilesTest.java
@@ -47,7 +47,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-public class WorkflowEntryCopyFilesTest {
+public class WorkflowActionCopyFilesTest {
   private ActionCopyFiles entry;
 
   private final String EMPTY = "";

--- a/plugins/actions/copymoveresultfilenames/src/main/java/org/apache/hop/workflow/actions/copymoveresultfilenames/ActionCopyMoveResultFilenamesDialog.java
+++ b/plugins/actions/copymoveresultfilenames/src/main/java/org/apache/hop/workflow/actions/copymoveresultfilenames/ActionCopyMoveResultFilenamesDialog.java
@@ -117,7 +117,7 @@ public class ActionCopyMoveResultFilenamesDialog extends ActionDialog implements
 
   public ActionCopyMoveResultFilenamesDialog( Shell parent, IAction action,
                                               WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionCopyMoveResultFilenames) action;
 
     if ( this.action.getName() == null ) {
@@ -210,7 +210,7 @@ public class ActionCopyMoveResultFilenamesDialog extends ActionDialog implements
     fdbFoldername.top = new FormAttachment( wAction, 0 );
     wbFoldername.setLayoutData(fdbFoldername);
 
-    wFoldername = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wFoldername = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wFoldername );
     wFoldername.addModifyListener( lsMod );
     FormData fdFoldername = new FormData();
@@ -220,9 +220,9 @@ public class ActionCopyMoveResultFilenamesDialog extends ActionDialog implements
     wFoldername.setLayoutData(fdFoldername);
 
     // Whenever something changes, set the tooltip to the expanded version:
-    wFoldername.addModifyListener( e -> wFoldername.setToolTipText( workflowMeta.environmentSubstitute( wFoldername.getText() ) ) );
+    wFoldername.addModifyListener( e -> wFoldername.setToolTipText( getWorkflowMeta().environmentSubstitute( wFoldername.getText() ) ) );
 
-    wbFoldername.addListener( SWT.Selection, e -> BaseDialog.presentDirectoryDialog( shell, wFoldername, workflowMeta ) );
+    wbFoldername.addListener( SWT.Selection, e -> BaseDialog.presentDirectoryDialog( shell, wFoldername, getWorkflowMeta() ) );
 
     // Create destination folder
     wlCreateDestinationFolder = new Label( shell, SWT.RIGHT );
@@ -497,7 +497,7 @@ public class ActionCopyMoveResultFilenamesDialog extends ActionDialog implements
     fdlWildcard.top = new FormAttachment( wSpecifyWildcard, margin );
     fdlWildcard.right = new FormAttachment( middle, -margin );
     wlWildcard.setLayoutData(fdlWildcard);
-    wWildcard = new TextVar( workflowMeta, wLimitTo, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wWildcard = new TextVar( getWorkflowMeta(), wLimitTo, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     wWildcard.setToolTipText( BaseMessages.getString( PKG, "ActionCopyMoveResultFilenames.Wildcard.Tooltip" ) );
     props.setLook( wWildcard );
     wWildcard.addModifyListener( lsMod );
@@ -508,7 +508,7 @@ public class ActionCopyMoveResultFilenamesDialog extends ActionDialog implements
     wWildcard.setLayoutData(fdWildcard);
 
     // Whenever something changes, set the tooltip to the expanded version:
-    wWildcard.addModifyListener( e -> wWildcard.setToolTipText( workflowMeta.environmentSubstitute( wWildcard.getText() ) ) );
+    wWildcard.addModifyListener( e -> wWildcard.setToolTipText( getWorkflowMeta().environmentSubstitute( wWildcard.getText() ) ) );
 
     // wWildcardExclude
     wlWildcardExclude = new Label(wLimitTo, SWT.RIGHT );
@@ -520,7 +520,7 @@ public class ActionCopyMoveResultFilenamesDialog extends ActionDialog implements
     fdlWildcardExclude.top = new FormAttachment( wWildcard, margin );
     fdlWildcardExclude.right = new FormAttachment( middle, -margin );
     wlWildcardExclude.setLayoutData(fdlWildcardExclude);
-    wWildcardExclude = new TextVar( workflowMeta, wLimitTo, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wWildcardExclude = new TextVar( getWorkflowMeta(), wLimitTo, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     wWildcardExclude.setToolTipText( BaseMessages.getString(
       PKG, "ActionCopyMoveResultFilenames.WildcardExclude.Tooltip" ) );
     props.setLook( wWildcardExclude );
@@ -532,7 +532,7 @@ public class ActionCopyMoveResultFilenamesDialog extends ActionDialog implements
     wWildcardExclude.setLayoutData(fdWildcardExclude);
 
     // Whenever something changes, set the tooltip to the expanded version:
-    wWildcardExclude.addModifyListener( e -> wWildcardExclude.setToolTipText( workflowMeta.environmentSubstitute( wWildcardExclude.getText() ) ) );
+    wWildcardExclude.addModifyListener( e -> wWildcardExclude.setToolTipText( getWorkflowMeta().environmentSubstitute( wWildcardExclude.getText() ) ) );
 
     FormData fdLimitTo = new FormData();
     fdLimitTo.left = new FormAttachment( 0, margin );
@@ -602,7 +602,7 @@ public class ActionCopyMoveResultFilenamesDialog extends ActionDialog implements
     wlNrErrorsLessThan.setLayoutData(fdlNrErrorsLessThan);
 
     wNrErrorsLessThan =
-      new TextVar( workflowMeta, wSuccessOn, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
+      new TextVar( getWorkflowMeta(), wSuccessOn, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
         PKG, "ActionCopyMoveResultFilenames.NrErrorsLessThan.Tooltip" ) );
     props.setLook( wNrErrorsLessThan );
     wNrErrorsLessThan.addModifyListener( lsMod );

--- a/plugins/actions/createfile/src/main/java/org/apache/hop/workflow/actions/createfile/ActionCreateFileDialog.java
+++ b/plugins/actions/createfile/src/main/java/org/apache/hop/workflow/actions/createfile/ActionCreateFileDialog.java
@@ -67,7 +67,7 @@ public class ActionCreateFileDialog extends ActionDialog implements IActionDialo
   private boolean changed;
 
   public ActionCreateFileDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionCreateFile) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "JobCreateFile.Name.Default" ) );
@@ -131,7 +131,7 @@ public class ActionCreateFileDialog extends ActionDialog implements IActionDialo
     fdbFilename.top = new FormAttachment( wName, 0 );
     wbFilename.setLayoutData(fdbFilename);
 
-    wFilename = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wFilename = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wFilename );
     wFilename.addModifyListener( lsMod );
     FormData fdFilename = new FormData();
@@ -141,9 +141,9 @@ public class ActionCreateFileDialog extends ActionDialog implements IActionDialo
     wFilename.setLayoutData(fdFilename);
 
     // Whenever something changes, set the tooltip to the expanded version:
-    wFilename.addModifyListener( e -> wFilename.setToolTipText( workflowMeta.environmentSubstitute( wFilename.getText() ) ) );
+    wFilename.addModifyListener( e -> wFilename.setToolTipText( getWorkflowMeta().environmentSubstitute( wFilename.getText() ) ) );
 
-    wbFilename.addListener( SWT.Selection, e-> BaseDialog.presentFileDialog( shell, wFilename, workflowMeta,
+    wbFilename.addListener( SWT.Selection, e-> BaseDialog.presentFileDialog( shell, wFilename, getWorkflowMeta(),
           new String[] { "*" }, FILETYPES, true )
     );
 

--- a/plugins/actions/createfolder/src/main/java/org/apache/hop/workflow/actions/createfolder/ActionCreateFolderDialog.java
+++ b/plugins/actions/createfolder/src/main/java/org/apache/hop/workflow/actions/createfolder/ActionCreateFolderDialog.java
@@ -62,7 +62,7 @@ public class ActionCreateFolderDialog extends ActionDialog implements IActionDia
   private boolean changed;
 
   public ActionCreateFolderDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionCreateFolder) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "JobCreateFolder.Name.Default" ) );
@@ -126,7 +126,7 @@ public class ActionCreateFolderDialog extends ActionDialog implements IActionDia
     fdbFoldername.top = new FormAttachment( wName, 0 );
     wbFoldername.setLayoutData(fdbFoldername);
 
-    wFoldername = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wFoldername = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wFoldername );
     wFoldername.addModifyListener( lsMod );
     FormData fdFoldername = new FormData();
@@ -136,9 +136,9 @@ public class ActionCreateFolderDialog extends ActionDialog implements IActionDia
     wFoldername.setLayoutData(fdFoldername);
 
     // Whenever something changes, set the tooltip to the expanded version:
-    wFoldername.addModifyListener( e -> wFoldername.setToolTipText( workflowMeta.environmentSubstitute( wFoldername.getText() ) ) );
+    wFoldername.addModifyListener( e -> wFoldername.setToolTipText( getWorkflowMeta().environmentSubstitute( wFoldername.getText() ) ) );
 
-    wbFoldername.addListener( SWT.Selection, e -> BaseDialog.presentDirectoryDialog( shell, wFoldername, workflowMeta ) );
+    wbFoldername.addListener( SWT.Selection, e -> BaseDialog.presentDirectoryDialog( shell, wFoldername, getWorkflowMeta() ) );
 
     Label wlAbortExists = new Label(shell, SWT.RIGHT);
     wlAbortExists.setText( BaseMessages.getString( PKG, "JobCreateFolder.FailIfExists.Label" ) );

--- a/plugins/actions/delay/src/main/java/org/apache/hop/workflow/actions/delay/ActionDelayDialog.java
+++ b/plugins/actions/delay/src/main/java/org/apache/hop/workflow/actions/delay/ActionDelayDialog.java
@@ -62,7 +62,7 @@ public class ActionDelayDialog extends ActionDialog implements IActionDialog {
   private boolean changed;
 
   public ActionDelayDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionDelay) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "ActionDelay.Title" ) );
@@ -110,8 +110,7 @@ public class ActionDelayDialog extends ActionDialog implements IActionDialog {
 
     // MaximumTimeout line
     wMaximumTimeout =
-      new LabelTextVar(
-        workflowMeta, shell, BaseMessages.getString( PKG, "ActionDelay.MaximumTimeout.Label" ), BaseMessages
+      new LabelTextVar(getWorkflowMeta(), shell, BaseMessages.getString( PKG, "ActionDelay.MaximumTimeout.Label" ), BaseMessages
         .getString( PKG, "ActionDelay.MaximumTimeout.Tooltip" ) );
     props.setLook( wMaximumTimeout );
     wMaximumTimeout.addModifyListener( lsMod );
@@ -122,7 +121,7 @@ public class ActionDelayDialog extends ActionDialog implements IActionDialog {
     wMaximumTimeout.setLayoutData(fdMaximumTimeout);
 
     // Whenever something changes, set the tooltip to the expanded version:
-    wMaximumTimeout.addModifyListener( e -> wMaximumTimeout.setToolTipText( workflowMeta.environmentSubstitute( wMaximumTimeout.getText() ) ) );
+    wMaximumTimeout.addModifyListener( e -> wMaximumTimeout.setToolTipText( getWorkflowMeta().environmentSubstitute( wMaximumTimeout.getText() ) ) );
 
     // Scale time
 

--- a/plugins/actions/deletefile/src/main/java/org/apache/hop/workflow/actions/deletefile/ActionDeleteFileDialog.java
+++ b/plugins/actions/deletefile/src/main/java/org/apache/hop/workflow/actions/deletefile/ActionDeleteFileDialog.java
@@ -65,7 +65,7 @@ public class ActionDeleteFileDialog extends ActionDialog implements IActionDialo
   private boolean changed;
 
   public ActionDeleteFileDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionDeleteFile) action;
 
     if ( this.action.getName() == null ) {
@@ -130,7 +130,7 @@ public class ActionDeleteFileDialog extends ActionDialog implements IActionDialo
     fdbFilename.top = new FormAttachment( wName, 0 );
     wbFilename.setLayoutData(fdbFilename);
 
-    wFilename = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wFilename = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wFilename );
     wFilename.addModifyListener( lsMod );
     FormData fdFilename = new FormData();
@@ -140,9 +140,9 @@ public class ActionDeleteFileDialog extends ActionDialog implements IActionDialo
     wFilename.setLayoutData(fdFilename);
 
     // Whenever something changes, set the tooltip to the expanded version:
-    wFilename.addModifyListener( e -> wFilename.setToolTipText( workflowMeta.environmentSubstitute( wFilename.getText() ) ) );
+    wFilename.addModifyListener( e -> wFilename.setToolTipText( getWorkflowMeta().environmentSubstitute( wFilename.getText() ) ) );
 
-    wbFilename.addListener( SWT.Selection, e-> BaseDialog.presentFileDialog( shell, wFilename, workflowMeta,
+    wbFilename.addListener( SWT.Selection, e-> BaseDialog.presentFileDialog( shell, wFilename, getWorkflowMeta(),
       new String[] { "*" }, FILETYPES, true )
     );
 

--- a/plugins/actions/deletefiles/src/main/java/org/apache/hop/workflow/actions/deletefiles/ActionDeleteFilesDialog.java
+++ b/plugins/actions/deletefiles/src/main/java/org/apache/hop/workflow/actions/deletefiles/ActionDeleteFilesDialog.java
@@ -68,7 +68,8 @@ public class ActionDeleteFilesDialog extends ActionDialog implements IActionDial
   private static final String[] FILETYPES = new String[] { BaseMessages.getString(
     PKG, "JobDeleteFiles.Filetype.All" ) };
 
-
+  private Shell shell;
+  
   private Text wName;
 
   private Label wlFilename;
@@ -96,7 +97,7 @@ public class ActionDeleteFilesDialog extends ActionDialog implements IActionDial
   private Button wbaFilename; // Add or change
 
   public ActionDeleteFilesDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionDeleteFiles) action;
 
     if ( this.action.getName() == null ) {
@@ -231,7 +232,7 @@ public class ActionDeleteFilesDialog extends ActionDialog implements IActionDial
     fdbDirectory.top = new FormAttachment( wSettings, margin );
     wbDirectory.setLayoutData( fdbDirectory );
 
-    wbDirectory.addListener( SWT.Selection, e -> BaseDialog.presentDirectoryDialog( shell, wFilename, workflowMeta ) );
+    wbDirectory.addListener( SWT.Selection, e -> BaseDialog.presentDirectoryDialog( shell, wFilename, getWorkflowMeta() ) );
 
     wbFilename = new Button( shell, SWT.PUSH | SWT.CENTER );
     props.setLook( wbFilename );
@@ -250,7 +251,7 @@ public class ActionDeleteFilesDialog extends ActionDialog implements IActionDial
     fdbaFilename.top = new FormAttachment( wSettings, margin );
     wbaFilename.setLayoutData( fdbaFilename );
 
-    wFilename = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wFilename = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wFilename );
     wFilename.addModifyListener( lsMod );
     FormData fdFilename = new FormData();
@@ -260,9 +261,9 @@ public class ActionDeleteFilesDialog extends ActionDialog implements IActionDial
     wFilename.setLayoutData( fdFilename );
 
     // Whenever something changes, set the tooltip to the expanded version:
-    wFilename.addModifyListener( ( ModifyEvent e ) -> wFilename.setToolTipText( workflowMeta.environmentSubstitute( wFilename.getText() ) ));
+    wFilename.addModifyListener( ( ModifyEvent e ) -> wFilename.setToolTipText( getWorkflowMeta().environmentSubstitute( wFilename.getText() ) ));
 
-    wbFilename.addListener( SWT.Selection, e -> BaseDialog.presentFileDialog( shell, wFilename, workflowMeta,
+    wbFilename.addListener( SWT.Selection, e -> BaseDialog.presentFileDialog( shell, wFilename, getWorkflowMeta(),
       new String[] { "*" }, FILETYPES, true )
     );
 
@@ -276,7 +277,7 @@ public class ActionDeleteFilesDialog extends ActionDialog implements IActionDial
     fdlFilemask.right = new FormAttachment( middle, -margin );
     wlFilemask.setLayoutData( fdlFilemask );
     wFilemask =
-      new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
+      new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
         PKG, "JobDeleteFiles.Wildcard.Tooltip" ) );
     props.setLook( wFilemask );
     wFilemask.addModifyListener( lsMod );
@@ -334,7 +335,7 @@ public class ActionDeleteFilesDialog extends ActionDialog implements IActionDial
 
     wFields =
       new TableView(
-        workflowMeta, shell, SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI, colinf, fieldsRows, lsMod, props );
+    		  getWorkflowMeta(), shell, SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI, colinf, fieldsRows, lsMod, props );
 
     FormData fdFields = new FormData();
     fdFields.left = new FormAttachment( 0, 0 );

--- a/plugins/actions/deletefolders/src/main/java/org/apache/hop/workflow/actions/deletefolders/ActionDeleteFoldersDialog.java
+++ b/plugins/actions/deletefolders/src/main/java/org/apache/hop/workflow/actions/deletefolders/ActionDeleteFoldersDialog.java
@@ -66,6 +66,8 @@ import org.eclipse.swt.widgets.Text;
 public class ActionDeleteFoldersDialog extends ActionDialog implements IActionDialog {
   private static final Class<?> PKG = ActionDeleteFolders.class; // for i18n purposes, needed by Translator!!
 
+  private Shell shell;
+  
   private Text wName;
 
   private Label wlFilename;
@@ -91,7 +93,7 @@ public class ActionDeleteFoldersDialog extends ActionDialog implements IActionDi
   private TextVar wLimitFolders;
 
   public ActionDeleteFoldersDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionDeleteFolders) action;
 
     if ( this.action.getName() == null ) {
@@ -239,7 +241,7 @@ public class ActionDeleteFoldersDialog extends ActionDialog implements IActionDi
     wlNrErrorsLessThan.setLayoutData( fdlNrErrorsLessThan );
 
     wLimitFolders =
-      new TextVar( workflowMeta, wSuccessOn, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
+      new TextVar( getWorkflowMeta(), wSuccessOn, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
         PKG, "JobDeleteFolders.LimitFolders.Tooltip" ) );
     props.setLook( wLimitFolders );
     wLimitFolders.addModifyListener( lsMod );
@@ -277,7 +279,7 @@ public class ActionDeleteFoldersDialog extends ActionDialog implements IActionDi
     fdbDirectory.top = new FormAttachment( wSuccessOn, margin );
     wbDirectory.setLayoutData( fdbDirectory );
 
-    wbDirectory.addListener( SWT.Selection, e->BaseDialog.presentDirectoryDialog( shell, wFilename, workflowMeta ));
+    wbDirectory.addListener( SWT.Selection, e->BaseDialog.presentDirectoryDialog( shell, wFilename, getWorkflowMeta() ));
     
     // Button Add or change
     wbaFilename = new Button( shell, SWT.PUSH | SWT.CENTER );
@@ -288,7 +290,7 @@ public class ActionDeleteFoldersDialog extends ActionDialog implements IActionDi
     fdbaFilename.top = new FormAttachment( wSuccessOn, margin );
     wbaFilename.setLayoutData( fdbaFilename );
 
-    wFilename = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wFilename = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wFilename );
     wFilename.addModifyListener( lsMod );
     FormData fdFilename = new FormData();
@@ -298,7 +300,7 @@ public class ActionDeleteFoldersDialog extends ActionDialog implements IActionDi
     wFilename.setLayoutData( fdFilename );
 
     // Whenever something changes, set the tooltip to the expanded version:
-    wFilename.addModifyListener( e -> wFilename.setToolTipText( workflowMeta.environmentSubstitute( wFilename.getText() ) ) );
+    wFilename.addModifyListener( e -> wFilename.setToolTipText( getWorkflowMeta().environmentSubstitute( wFilename.getText() ) ) );
 
     // Button Delete
     wbdFilename = new Button( shell, SWT.PUSH | SWT.CENTER );
@@ -343,7 +345,7 @@ public class ActionDeleteFoldersDialog extends ActionDialog implements IActionDi
 
     wFields =
       new TableView(
-        workflowMeta, shell, SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI, colinf, FieldsRows, lsMod, props );
+    		  getWorkflowMeta(), shell, SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI, colinf, FieldsRows, lsMod, props );
 
     FormData fdFields = new FormData();
     fdFields.left = new FormAttachment( 0, 0 );

--- a/plugins/actions/deleteresultfilenames/src/main/java/org/apache/hop/workflow/actions/deleteresultfilenames/ActionDeleteResultFilenamesDialog.java
+++ b/plugins/actions/deleteresultfilenames/src/main/java/org/apache/hop/workflow/actions/deleteresultfilenames/ActionDeleteResultFilenamesDialog.java
@@ -66,7 +66,7 @@ public class ActionDeleteResultFilenamesDialog extends ActionDialog implements I
 
   public ActionDeleteResultFilenamesDialog( Shell parent, IAction action,
                                             WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionDeleteResultFilenames) action;
 
     if ( this.action.getName() == null ) {
@@ -148,7 +148,7 @@ public class ActionDeleteResultFilenamesDialog extends ActionDialog implements I
     fdlWildcard.top = new FormAttachment( wSpecifyWildcard, margin );
     fdlWildcard.right = new FormAttachment( middle, -margin );
     wlWildcard.setLayoutData(fdlWildcard);
-    wWildcard = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wWildcard = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     wWildcard.setToolTipText( BaseMessages.getString( PKG, "ActionDeleteResultFilenames.Wildcard.Tooltip" ) );
     props.setLook( wWildcard );
     wWildcard.addModifyListener( lsMod );
@@ -159,7 +159,7 @@ public class ActionDeleteResultFilenamesDialog extends ActionDialog implements I
     wWildcard.setLayoutData(fdWildcard);
 
     // Whenever something changes, set the tooltip to the expanded version:
-    wWildcard.addModifyListener( e -> wWildcard.setToolTipText( workflowMeta.environmentSubstitute( wWildcard.getText() ) ) );
+    wWildcard.addModifyListener( e -> wWildcard.setToolTipText( getWorkflowMeta().environmentSubstitute( wWildcard.getText() ) ) );
 
     // wWildcardExclude
     wlWildcardExclude = new Label( shell, SWT.RIGHT );
@@ -171,7 +171,7 @@ public class ActionDeleteResultFilenamesDialog extends ActionDialog implements I
     fdlWildcardExclude.top = new FormAttachment( wWildcard, margin );
     fdlWildcardExclude.right = new FormAttachment( middle, -margin );
     wlWildcardExclude.setLayoutData(fdlWildcardExclude);
-    wWildcardExclude = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wWildcardExclude = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     wWildcardExclude.setToolTipText( BaseMessages.getString(
       PKG, "ActionDeleteResultFilenames.WildcardExclude.Tooltip" ) );
     props.setLook( wWildcardExclude );
@@ -183,7 +183,7 @@ public class ActionDeleteResultFilenamesDialog extends ActionDialog implements I
     wWildcardExclude.setLayoutData(fdWildcardExclude);
 
     // Whenever something changes, set the tooltip to the expanded version:
-    wWildcardExclude.addModifyListener( e -> wWildcardExclude.setToolTipText( workflowMeta.environmentSubstitute( wWildcardExclude.getText() ) ) );
+    wWildcardExclude.addModifyListener( e -> wWildcardExclude.setToolTipText( getWorkflowMeta().environmentSubstitute( wWildcardExclude.getText() ) ) );
 
     Button wOk = new Button(shell, SWT.PUSH);
     wOk.setText( BaseMessages.getString( PKG, "System.Button.OK" ) );

--- a/plugins/actions/dostounix/src/main/java/org/apache/hop/workflow/actions/dostounix/ActionDosToUnixDialog.java
+++ b/plugins/actions/dostounix/src/main/java/org/apache/hop/workflow/actions/dostounix/ActionDosToUnixDialog.java
@@ -95,7 +95,7 @@ public class ActionDosToUnixDialog extends ActionDialog implements IActionDialog
   private TextVar wNrErrorsLessThan;
 
   public ActionDosToUnixDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionDosToUnix) action;
 
     if ( this.action.getName() == null ) {
@@ -251,7 +251,7 @@ public class ActionDosToUnixDialog extends ActionDialog implements IActionDialog
     fdbSourceDirectory.top = new FormAttachment(wSettings, margin );
     wbSourceDirectory.setLayoutData(fdbSourceDirectory);
 
-    wbSourceDirectory.addListener( SWT.Selection, e->BaseDialog.presentDirectoryDialog( shell, wSourceFileFolder, workflowMeta ));
+    wbSourceDirectory.addListener( SWT.Selection, e->BaseDialog.presentDirectoryDialog( shell, wSourceFileFolder, getWorkflowMeta() ));
 
     // Browse Source files button ...
     wbSourceFileFolder = new Button(wGeneralComp, SWT.PUSH | SWT.CENTER );
@@ -271,7 +271,7 @@ public class ActionDosToUnixDialog extends ActionDialog implements IActionDialog
     fdbaSourceFileFolder.top = new FormAttachment(wSettings, margin );
     wbaSourceFileFolder.setLayoutData(fdbaSourceFileFolder);
 
-    wSourceFileFolder = new TextVar( workflowMeta, wGeneralComp, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wSourceFileFolder = new TextVar( getWorkflowMeta(), wGeneralComp, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     wSourceFileFolder.setToolTipText( BaseMessages.getString( PKG, "JobDosToUnix.SourceFileFolder.Tooltip" ) );
 
     props.setLook( wSourceFileFolder );
@@ -283,9 +283,9 @@ public class ActionDosToUnixDialog extends ActionDialog implements IActionDialog
     wSourceFileFolder.setLayoutData(fdSourceFileFolder);
 
     // Whenever something changes, set the tooltip to the expanded version:
-    wSourceFileFolder.addModifyListener( e -> wSourceFileFolder.setToolTipText( workflowMeta.environmentSubstitute( wSourceFileFolder.getText() ) ) );
+    wSourceFileFolder.addModifyListener( e -> wSourceFileFolder.setToolTipText( getWorkflowMeta().environmentSubstitute( wSourceFileFolder.getText() ) ) );
 
-    wbSourceFileFolder.addListener( SWT.Selection, e-> BaseDialog.presentFileDialog( shell, wSourceFileFolder, workflowMeta,
+    wbSourceFileFolder.addListener( SWT.Selection, e-> BaseDialog.presentFileDialog( shell, wSourceFileFolder, getWorkflowMeta(),
       new String[] { "*.xml;*.XML", "*" }, FILETYPES, true )
     );
 
@@ -319,7 +319,7 @@ public class ActionDosToUnixDialog extends ActionDialog implements IActionDialog
     fdlWildcard.right = new FormAttachment( middle, -margin );
     wlWildcard.setLayoutData(fdlWildcard);
 
-    wWildcard = new TextVar( workflowMeta, wGeneralComp, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wWildcard = new TextVar( getWorkflowMeta(), wGeneralComp, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     wWildcard.setToolTipText( BaseMessages.getString( PKG, "JobDosToUnix.Wildcard.Tooltip" ) );
     props.setLook( wWildcard );
     wWildcard.addModifyListener( lsMod );
@@ -362,7 +362,7 @@ public class ActionDosToUnixDialog extends ActionDialog implements IActionDialog
 
     wFields =
       new TableView(
-        workflowMeta, wGeneralComp, SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI, colinf, FieldsRows, lsMod, props );
+    		  getWorkflowMeta(), wGeneralComp, SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI, colinf, FieldsRows, lsMod, props );
 
     FormData fdFields = new FormData();
     fdFields.left = new FormAttachment( 0, 0 );
@@ -496,7 +496,7 @@ public class ActionDosToUnixDialog extends ActionDialog implements IActionDialog
     wlNrErrorsLessThan.setLayoutData(fdlNrErrorsLessThan);
 
     wNrErrorsLessThan =
-      new TextVar( workflowMeta, wSuccessOn, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
+      new TextVar( getWorkflowMeta(), wSuccessOn, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
         PKG, "JobDosToUnix.NrErrorFilesCountLessThan.Tooltip" ) );
     props.setLook( wNrErrorsLessThan );
     wNrErrorsLessThan.addModifyListener( lsMod );

--- a/plugins/actions/eval/src/main/java/org/apache/hop/workflow/actions/eval/ActionEvalDialog.java
+++ b/plugins/actions/eval/src/main/java/org/apache/hop/workflow/actions/eval/ActionEvalDialog.java
@@ -63,7 +63,7 @@ public class ActionEvalDialog extends ActionDialog implements IActionDialog {
   private boolean changed;
 
   public ActionEvalDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionEval) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "ActionEval.Name.Default" ) );

--- a/plugins/actions/evalfilesmetrics/src/main/java/org/apache/hop/workflow/actions/evalfilesmetrics/ActionEvalFilesMetricsDialog.java
+++ b/plugins/actions/evalfilesmetrics/src/main/java/org/apache/hop/workflow/actions/evalfilesmetrics/ActionEvalFilesMetricsDialog.java
@@ -114,7 +114,7 @@ public class ActionEvalFilesMetricsDialog extends ActionDialog implements IActio
 
   public ActionEvalFilesMetricsDialog( Shell parent, IAction action,
                                        WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionEvalFilesMetrics) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "JobEvalFilesMetrics.Name.Default" ) );
@@ -230,7 +230,7 @@ public class ActionEvalFilesMetricsDialog extends ActionDialog implements IActio
     fdlResultFilenamesWildcard.right = new FormAttachment( middle, -margin );
     wlResultFilenamesWildcard.setLayoutData(fdlResultFilenamesWildcard);
 
-    wResultFilenamesWildcard = new TextVar( workflowMeta, wSettings, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wResultFilenamesWildcard = new TextVar( getWorkflowMeta(), wSettings, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     wResultFilenamesWildcard.setToolTipText( BaseMessages.getString(
       PKG, "JobEvalFilesMetrics.ResultFilenamesWildcard.Tooltip" ) );
     props.setLook( wResultFilenamesWildcard );
@@ -251,7 +251,7 @@ public class ActionEvalFilesMetricsDialog extends ActionDialog implements IActio
     fdlResultFieldFile.right = new FormAttachment( middle, -margin );
     wlResultFieldFile.setLayoutData(fdlResultFieldFile);
 
-    wResultFieldFile = new TextVar( workflowMeta, wSettings, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wResultFieldFile = new TextVar( getWorkflowMeta(), wSettings, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     wResultFieldFile.setToolTipText( BaseMessages.getString( PKG, "JobEvalFilesMetrics.ResultFieldFile.Tooltip" ) );
     props.setLook( wResultFieldFile );
     wResultFieldFile.addModifyListener( lsMod );
@@ -272,7 +272,7 @@ public class ActionEvalFilesMetricsDialog extends ActionDialog implements IActio
     fdlResultFieldWildcard.right = new FormAttachment( middle, -margin );
     wlResultFieldWildcard.setLayoutData(fdlResultFieldWildcard);
 
-    wResultFieldWildcard = new TextVar( workflowMeta, wSettings, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wResultFieldWildcard = new TextVar( getWorkflowMeta(), wSettings, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     wResultFieldWildcard.setToolTipText( BaseMessages.getString(
       PKG, "JobEvalWildcardsMetrics.ResultFieldWildcard.Tooltip" ) );
     props.setLook( wResultFieldWildcard );
@@ -294,7 +294,7 @@ public class ActionEvalFilesMetricsDialog extends ActionDialog implements IActio
     fdlResultFieldIncludeSubFolders.right = new FormAttachment( middle, -margin );
     wlResultFieldIncludeSubFolders.setLayoutData(fdlResultFieldIncludeSubFolders);
 
-    wResultFieldIncludeSubFolders = new TextVar( workflowMeta, wSettings, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wResultFieldIncludeSubFolders = new TextVar( getWorkflowMeta(), wSettings, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     wResultFieldIncludeSubFolders.setToolTipText( BaseMessages.getString(
       PKG, "JobEvalIncludeSubFolderssMetrics.ResultFieldIncludeSubFolders.Tooltip" ) );
     props.setLook( wResultFieldIncludeSubFolders );
@@ -361,7 +361,7 @@ public class ActionEvalFilesMetricsDialog extends ActionDialog implements IActio
     fdbSourceDirectory.top = new FormAttachment(wSettings, margin );
     wbSourceDirectory.setLayoutData(fdbSourceDirectory);
 
-    wbSourceDirectory.addListener( SWT.Selection, e-> BaseDialog.presentDirectoryDialog( shell, wSourceFileFolder, workflowMeta ));
+    wbSourceDirectory.addListener( SWT.Selection, e-> BaseDialog.presentDirectoryDialog( shell, wSourceFileFolder, getWorkflowMeta() ));
 
     // Browse Source files button ...
     wbSourceFileFolder = new Button(wGeneralComp, SWT.PUSH | SWT.CENTER );
@@ -381,7 +381,7 @@ public class ActionEvalFilesMetricsDialog extends ActionDialog implements IActio
     fdbaSourceFileFolder.top = new FormAttachment(wSettings, margin );
     wbaSourceFileFolder.setLayoutData(fdbaSourceFileFolder);
 
-    wSourceFileFolder = new TextVar( workflowMeta, wGeneralComp, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wSourceFileFolder = new TextVar( getWorkflowMeta(), wGeneralComp, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     wSourceFileFolder
       .setToolTipText( BaseMessages.getString( PKG, "JobEvalFilesMetrics.SourceFileFolder.Tooltip" ) );
 
@@ -394,9 +394,9 @@ public class ActionEvalFilesMetricsDialog extends ActionDialog implements IActio
     wSourceFileFolder.setLayoutData(fdSourceFileFolder);
 
     // Whenever something changes, set the tooltip to the expanded version:
-    wSourceFileFolder.addModifyListener( e -> wSourceFileFolder.setToolTipText( workflowMeta.environmentSubstitute( wSourceFileFolder.getText() ) ) );
+    wSourceFileFolder.addModifyListener( e -> wSourceFileFolder.setToolTipText( getWorkflowMeta().environmentSubstitute( wSourceFileFolder.getText() ) ) );
 
-    wbSourceFileFolder.addListener( SWT.Selection, e-> BaseDialog.presentFileDialog( shell, wSourceFileFolder, workflowMeta,
+    wbSourceFileFolder.addListener( SWT.Selection, e-> BaseDialog.presentFileDialog( shell, wSourceFileFolder, getWorkflowMeta(),
       new String[] { "*" }, FILETYPES, true )
     );
 
@@ -431,7 +431,7 @@ public class ActionEvalFilesMetricsDialog extends ActionDialog implements IActio
     fdlWildcard.right = new FormAttachment( middle, -margin );
     wlWildcard.setLayoutData(fdlWildcard);
 
-    wWildcard = new TextVar( workflowMeta, wGeneralComp, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wWildcard = new TextVar( getWorkflowMeta(), wGeneralComp, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     wWildcard.setToolTipText( BaseMessages.getString( PKG, "JobEvalFilesMetrics.Wildcard.Tooltip" ) );
     props.setLook( wWildcard );
     wWildcard.addModifyListener( lsMod );
@@ -473,7 +473,7 @@ public class ActionEvalFilesMetricsDialog extends ActionDialog implements IActio
 
     wFields =
       new TableView(
-        workflowMeta, wGeneralComp, SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI, colinf, FieldsRows, lsMod, props );
+    		  getWorkflowMeta(), wGeneralComp, SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI, colinf, FieldsRows, lsMod, props );
 
     FormData fdFields = new FormData();
     fdFields.left = new FormAttachment( 0, 0 );
@@ -633,7 +633,7 @@ public class ActionEvalFilesMetricsDialog extends ActionDialog implements IActio
     wlCompareValue.setLayoutData(fdlCompareValue);
 
     wCompareValue =
-      new TextVar( workflowMeta, wSuccessOn, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
+      new TextVar( getWorkflowMeta(), wSuccessOn, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
         PKG, "JobEvalFilesMetricsDialog.CompareValue.Tooltip" ) );
     props.setLook( wCompareValue );
     wCompareValue.addModifyListener( lsMod );
@@ -654,7 +654,7 @@ public class ActionEvalFilesMetricsDialog extends ActionDialog implements IActio
     wlMinValue.setLayoutData(fdlMinValue);
 
     wMinValue =
-      new TextVar( workflowMeta, wSuccessOn, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
+      new TextVar( getWorkflowMeta(), wSuccessOn, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
         PKG, "JobEvalFilesMetricsDialog.MinValue.Tooltip" ) );
     props.setLook( wMinValue );
     wMinValue.addModifyListener( lsMod );
@@ -675,7 +675,7 @@ public class ActionEvalFilesMetricsDialog extends ActionDialog implements IActio
     wlMaxValue.setLayoutData(fdlMaxValue);
 
     wMaxValue =
-      new TextVar( workflowMeta, wSuccessOn, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
+      new TextVar( getWorkflowMeta(), wSuccessOn, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
         PKG, "JobEvalFilesMetricsDialog.MaxValue.Tooltip" ) );
     props.setLook( wMaxValue );
     wMaxValue.addModifyListener( lsMod );

--- a/plugins/actions/evaluatetablecontent/src/main/java/org/apache/hop/workflow/actions/evaluatetablecontent/ActionEvalTableContentDialog.java
+++ b/plugins/actions/evaluatetablecontent/src/main/java/org/apache/hop/workflow/actions/evaluatetablecontent/ActionEvalTableContentDialog.java
@@ -107,7 +107,7 @@ public class ActionEvalTableContentDialog extends ActionDialog implements IActio
 
   public ActionEvalTableContentDialog( Shell parent, IAction action,
                                        WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionEvalTableContent) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "ActionEvalTableContent.Name.Default" ) );
@@ -184,7 +184,7 @@ public class ActionEvalTableContentDialog extends ActionDialog implements IActio
     fdlSchemaname.top = new FormAttachment( wConnection, margin );
     wlSchemaname.setLayoutData(fdlSchemaname);
 
-    wSchemaname = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wSchemaname = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wSchemaname );
     wSchemaname.setToolTipText( BaseMessages.getString( PKG, "ActionEvalTableContent.Schemaname.Tooltip" ) );
     wSchemaname.addModifyListener( lsMod );
@@ -217,7 +217,7 @@ public class ActionEvalTableContentDialog extends ActionDialog implements IActio
       }
     } );
 
-    wTablename = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wTablename = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wTablename );
     wTablename.setToolTipText( BaseMessages.getString( PKG, "ActionEvalTableContent.Tablename.Tooltip" ) );
     wTablename.addModifyListener( lsMod );
@@ -276,7 +276,7 @@ public class ActionEvalTableContentDialog extends ActionDialog implements IActio
     wlLimit.setLayoutData(fdlLimit);
 
     wLimit =
-      new TextVar( workflowMeta, wSuccessGroup, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
+      new TextVar( getWorkflowMeta(), wSuccessGroup, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
         PKG, "ActionEvalTableContent.Limit.Tooltip" ) );
     props.setLook( wLimit );
     wLimit.addModifyListener( lsMod );
@@ -527,9 +527,9 @@ public class ActionEvalTableContentDialog extends ActionDialog implements IActio
   }
 
   private void getSql() {
-    DatabaseMeta inf = workflowMeta.findDatabase( wConnection.getText() );
+    DatabaseMeta inf = getWorkflowMeta().findDatabase( wConnection.getText() );
     if ( inf != null ) {
-      DatabaseExplorerDialog std = new DatabaseExplorerDialog( shell, SWT.NONE, inf, workflowMeta.getDatabases() );
+      DatabaseExplorerDialog std = new DatabaseExplorerDialog( shell, SWT.NONE, inf, getWorkflowMeta().getDatabases() );
       if ( std.open() ) {
         String sql =
           "SELECT *"
@@ -692,7 +692,7 @@ public class ActionEvalTableContentDialog extends ActionDialog implements IActio
       return;
     }
     action.setName( wName.getText() );
-    action.setDatabase( workflowMeta.findDatabase( wConnection.getText() ) );
+    action.setDatabase( getWorkflowMeta().findDatabase( wConnection.getText() ) );
 
     action.setSchemaname( wSchemaname.getText() );
     action.setTablename( wTablename.getText() );
@@ -710,9 +710,9 @@ public class ActionEvalTableContentDialog extends ActionDialog implements IActio
   private void getTableName() {
     String databaseName = wConnection.getText();
     if ( StringUtils.isNotEmpty( databaseName ) ) {
-      DatabaseMeta databaseMeta = workflowMeta.findDatabase( databaseName );
+      DatabaseMeta databaseMeta = getWorkflowMeta().findDatabase( databaseName );
       if ( databaseMeta != null ) {
-        DatabaseExplorerDialog std = new DatabaseExplorerDialog( shell, SWT.NONE, databaseMeta, workflowMeta.getDatabases() );
+        DatabaseExplorerDialog std = new DatabaseExplorerDialog( shell, SWT.NONE, databaseMeta, getWorkflowMeta().getDatabases() );
         std.setSelectedSchemaAndTable( wSchemaname.getText(), wTablename.getText() );
         if ( std.open() ) {
           wTablename.setText( Const.NVL( std.getTableName(), "" ) );

--- a/plugins/actions/filecompare/src/main/java/org/apache/hop/workflow/actions/filecompare/ActionFileCompareDialog.java
+++ b/plugins/actions/filecompare/src/main/java/org/apache/hop/workflow/actions/filecompare/ActionFileCompareDialog.java
@@ -66,7 +66,7 @@ public class ActionFileCompareDialog extends ActionDialog implements IActionDial
   private boolean changed;
 
   public ActionFileCompareDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionFileCompare) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "JobFileCompare.Name.Default" ) );
@@ -128,7 +128,7 @@ public class ActionFileCompareDialog extends ActionDialog implements IActionDial
     fdbFilename1.right = new FormAttachment( 100, 0 );
     fdbFilename1.top = new FormAttachment( wName, 0 );
     wbFilename1.setLayoutData(fdbFilename1);
-    wFilename1 = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wFilename1 = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wFilename1 );
     wFilename1.addModifyListener( lsMod );
     FormData fdFilename1 = new FormData();
@@ -138,9 +138,9 @@ public class ActionFileCompareDialog extends ActionDialog implements IActionDial
     wFilename1.setLayoutData(fdFilename1);
 
     // Whenever something changes, set the tooltip to the expanded version:
-    wFilename1.addModifyListener( e -> wFilename1.setToolTipText( workflowMeta.environmentSubstitute( wFilename1.getText() ) ) );
+    wFilename1.addModifyListener( e -> wFilename1.setToolTipText( getWorkflowMeta().environmentSubstitute( wFilename1.getText() ) ) );
 
-    wbFilename1.addListener( SWT.Selection, e-> BaseDialog.presentFileDialog( shell, wFilename1, workflowMeta,
+    wbFilename1.addListener( SWT.Selection, e-> BaseDialog.presentFileDialog( shell, wFilename1, getWorkflowMeta(),
       new String[] { "*" }, FILETYPES, true )
     );
 
@@ -160,7 +160,7 @@ public class ActionFileCompareDialog extends ActionDialog implements IActionDial
     fdbFilename2.right = new FormAttachment( 100, 0 );
     fdbFilename2.top = new FormAttachment( wFilename1, 0 );
     wbFilename2.setLayoutData(fdbFilename2);
-    wFilename2 = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wFilename2 = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wFilename2 );
     wFilename2.addModifyListener( lsMod );
     FormData fdFilename2 = new FormData();
@@ -170,9 +170,9 @@ public class ActionFileCompareDialog extends ActionDialog implements IActionDial
     wFilename2.setLayoutData(fdFilename2);
 
     // Whenever something changes, set the tooltip to the expanded version:
-    wFilename2.addModifyListener( e -> wFilename2.setToolTipText( workflowMeta.environmentSubstitute( wFilename2.getText() ) ) );
+    wFilename2.addModifyListener( e -> wFilename2.setToolTipText( getWorkflowMeta().environmentSubstitute( wFilename2.getText() ) ) );
 
-    wbFilename2.addListener( SWT.Selection, e-> BaseDialog.presentFileDialog( shell, wFilename2, workflowMeta,
+    wbFilename2.addListener( SWT.Selection, e-> BaseDialog.presentFileDialog( shell, wFilename2, getWorkflowMeta(),
       new String[] { "*" }, FILETYPES, true )
     );
 

--- a/plugins/actions/fileexists/src/main/java/org/apache/hop/workflow/actions/fileexists/ActionFileExistsDialog.java
+++ b/plugins/actions/fileexists/src/main/java/org/apache/hop/workflow/actions/fileexists/ActionFileExistsDialog.java
@@ -68,7 +68,7 @@ public class ActionFileExistsDialog extends ActionDialog implements IActionDialo
   private boolean changed;
 
   public ActionFileExistsDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionFileExists) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "JobFileExists.Name.Default" ) );
@@ -133,7 +133,7 @@ public class ActionFileExistsDialog extends ActionDialog implements IActionDialo
     // fdbFilename.height = 22;
     wbFilename.setLayoutData(fdbFilename);
 
-    wFilename = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wFilename = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wFilename );
     wFilename.addModifyListener( lsMod );
     FormData fdFilename = new FormData();
@@ -143,8 +143,8 @@ public class ActionFileExistsDialog extends ActionDialog implements IActionDialo
     wFilename.setLayoutData(fdFilename);
 
     // Whenever something changes, set the tooltip to the expanded version:
-    wFilename.addModifyListener( e -> wFilename.setToolTipText( workflowMeta.environmentSubstitute( wFilename.getText() ) ) );
-    wbFilename.addListener( SWT.Selection, e-> BaseDialog.presentFileDialog(shell, wFilename, workflowMeta, EXTENSIONS, FILETYPES, false));
+    wFilename.addModifyListener( e -> wFilename.setToolTipText( getWorkflowMeta().environmentSubstitute( wFilename.getText() ) ) );
+    wbFilename.addListener( SWT.Selection, e-> BaseDialog.presentFileDialog(shell, wFilename, getWorkflowMeta(), EXTENSIONS, FILETYPES, false));
 
     Button wOk = new Button(shell, SWT.PUSH);
     wOk.setText( BaseMessages.getString( PKG, "System.Button.OK" ) );

--- a/plugins/actions/filesexist/src/main/java/org/apache/hop/workflow/actions/filesexist/ActionFilesExistDialog.java
+++ b/plugins/actions/filesexist/src/main/java/org/apache/hop/workflow/actions/filesexist/ActionFilesExistDialog.java
@@ -70,7 +70,7 @@ public class ActionFilesExistDialog extends ActionDialog implements IActionDialo
   private TableView wFields;
 
   public ActionFilesExistDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionFilesExist) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "JobFilesExist.Name.Default" ) );
@@ -136,7 +136,7 @@ public class ActionFilesExistDialog extends ActionDialog implements IActionDialo
     fdbDirectory.top = new FormAttachment( wName, margin );
     wbDirectory.setLayoutData(fdbDirectory);
 
-    wbDirectory.addListener( SWT.Selection, e-> BaseDialog.presentDirectoryDialog( shell, wFilename, workflowMeta ));
+    wbDirectory.addListener( SWT.Selection, e-> BaseDialog.presentDirectoryDialog( shell, wFilename, getWorkflowMeta() ));
 
     Button wbFilename = new Button(shell, SWT.PUSH | SWT.CENTER);
     props.setLook(wbFilename);
@@ -156,7 +156,7 @@ public class ActionFilesExistDialog extends ActionDialog implements IActionDialo
     fdbaFilename.top = new FormAttachment( wName, margin );
     wbaFilename.setLayoutData(fdbaFilename);
 
-    wFilename = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wFilename = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wFilename );
     wFilename.addModifyListener( lsMod );
     FormData fdFilename = new FormData();
@@ -167,9 +167,9 @@ public class ActionFilesExistDialog extends ActionDialog implements IActionDialo
 
 
     // Whenever something changes, set the tooltip to the expanded version:
-    wFilename.addModifyListener( e -> wFilename.setToolTipText( workflowMeta.environmentSubstitute( wFilename.getText() ) ) );
+    wFilename.addModifyListener( e -> wFilename.setToolTipText( getWorkflowMeta().environmentSubstitute( wFilename.getText() ) ) );
 
-    wbFilename.addListener( SWT.Selection, e-> BaseDialog.presentFileDialog( shell, wFilename, workflowMeta,
+    wbFilename.addListener( SWT.Selection, e-> BaseDialog.presentFileDialog( shell, wFilename, getWorkflowMeta(),
       new String[] { "*" }, FILETYPES, true )
     );
 
@@ -219,7 +219,7 @@ public class ActionFilesExistDialog extends ActionDialog implements IActionDialo
 
     wFields =
       new TableView(
-        workflowMeta, shell, SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI, colinf, FieldsRows, lsMod, props );
+    		  getWorkflowMeta(), shell, SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI, colinf, FieldsRows, lsMod, props );
 
     FormData fdFields = new FormData();
     fdFields.left = new FormAttachment( 0, 0 );

--- a/plugins/actions/filesexist/src/test/java/org/apache/hop/workflow/actions/filesexist/WorkflowActionFilesExistTest.java
+++ b/plugins/actions/filesexist/src/test/java/org/apache/hop/workflow/actions/filesexist/WorkflowActionFilesExistTest.java
@@ -41,9 +41,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
-public class WorkflowEntryFilesExistTest {
+public class WorkflowActionFilesExistTest {
   private IWorkflowEngine<WorkflowMeta> workflow;
-  private ActionFilesExist entry;
+  private ActionFilesExist action;
 
   private String existingFile1;
   private String existingFile2;
@@ -53,17 +53,17 @@ public class WorkflowEntryFilesExistTest {
   @Before
   public void setUp() throws Exception {
     workflow = new LocalWorkflowEngine( new WorkflowMeta() );
-    entry = new ActionFilesExist();
+    action = new ActionFilesExist();
 
-    workflow.getWorkflowMeta().addAction( new ActionMeta( entry ) );
-    entry.setParentWorkflow( workflow );
+    workflow.getWorkflowMeta().addAction( new ActionMeta( action ) );
+    action.setParentWorkflow( workflow );
     WorkflowMeta mockWorkflowMeta = mock( WorkflowMeta.class );
-    entry.setParentWorkflowMeta( mockWorkflowMeta );
+    action.setParentWorkflowMeta( mockWorkflowMeta );
 
     workflow.setStopped( false );
 
-    existingFile1 = TestUtils.createRamFile( getClass().getSimpleName() + "/existingFile1.ext", entry );
-    existingFile2 = TestUtils.createRamFile( getClass().getSimpleName() + "/existingFile2.ext", entry );
+    existingFile1 = TestUtils.createRamFile( getClass().getSimpleName() + "/existingFile1.ext", action );
+    existingFile2 = TestUtils.createRamFile( getClass().getSimpleName() + "/existingFile2.ext", action );
   }
 
   @After
@@ -73,9 +73,9 @@ public class WorkflowEntryFilesExistTest {
   @Test
   public void testSetNrErrorsNewBehaviorFalseResult() throws Exception {
     // this tests fix for PDI-10270
-    entry.setArguments( new String[] { "nonExistingFile.ext" } );
+    action.setArguments( new String[] { "nonExistingFile.ext" } );
 
-    Result res = entry.execute( new Result(), 0 );
+    Result res = action.execute( new Result(), 0 );
 
     assertFalse( "Entry should fail", res.getResult() );
     assertEquals( "Files not found. Result is false. But... No of errors should be zero", 0, res.getNrErrors() );
@@ -84,23 +84,23 @@ public class WorkflowEntryFilesExistTest {
   @Test
   public void testSetNrErrorsOldBehaviorFalseResult() throws Exception {
     // this tests backward compatibility settings for PDI-10270
-    entry.setArguments( new String[] { "nonExistingFile1.ext", "nonExistingFile2.ext" } );
+    action.setArguments( new String[] { "nonExistingFile1.ext", "nonExistingFile2.ext" } );
 
-    entry.setVariable( Const.HOP_COMPATIBILITY_SET_ERROR_ON_SPECIFIC_WORKFLOW_ACTIONS, "Y" );
+    action.setVariable( Const.HOP_COMPATIBILITY_SET_ERROR_ON_SPECIFIC_WORKFLOW_ACTIONS, "Y" );
 
-    Result res = entry.execute( new Result(), 0 );
+    Result res = action.execute( new Result(), 0 );
 
     assertFalse( "Entry should fail", res.getResult() );
     assertEquals(
       "Files not found. Result is false. And... Number of errors should be the same as number of not found files",
-      entry.getArguments().length, res.getNrErrors() );
+      action.getArguments().length, res.getNrErrors() );
   }
 
   @Test
   public void testExecuteWithException() throws Exception {
-    entry.setArguments( new String[] { null } );
+    action.setArguments( new String[] { null } );
 
-    Result res = entry.execute( new Result(), 0 );
+    Result res = action.execute( new Result(), 0 );
 
     assertFalse( "Entry should fail", res.getResult() );
     assertEquals( "File with wrong name was specified. One error should be reported", 1, res.getNrErrors() );
@@ -108,19 +108,19 @@ public class WorkflowEntryFilesExistTest {
 
   @Test
   public void testExecuteSuccess() throws Exception {
-    entry.setArguments( new String[] { existingFile1, existingFile2 } );
+    action.setArguments( new String[] { existingFile1, existingFile2 } );
 
-    Result res = entry.execute( new Result(), 0 );
+    Result res = action.execute( new Result(), 0 );
 
     assertTrue( "Entry failed", res.getResult() );
   }
 
   @Test
   public void testExecuteFail() throws Exception {
-    entry.setArguments(
+    action.setArguments(
       new String[] { existingFile1, existingFile2, "nonExistingFile1.ext", "nonExistingFile2.ext" } );
 
-    Result res = entry.execute( new Result(), 0 );
+    Result res = action.execute( new Result(), 0 );
 
     assertFalse( "Entry should fail", res.getResult() );
   }

--- a/plugins/actions/folderisempty/src/main/java/org/apache/hop/workflow/actions/folderisempty/ActionFolderIsEmptyDialog.java
+++ b/plugins/actions/folderisempty/src/main/java/org/apache/hop/workflow/actions/folderisempty/ActionFolderIsEmptyDialog.java
@@ -68,7 +68,7 @@ public class ActionFolderIsEmptyDialog extends ActionDialog implements IActionDi
   private boolean changed;
 
   public ActionFolderIsEmptyDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionFolderIsEmpty) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "JobFolderIsEmpty.Name.Default" ) );
@@ -132,7 +132,7 @@ public class ActionFolderIsEmptyDialog extends ActionDialog implements IActionDi
     fdbFoldername.top = new FormAttachment( wName, 0 );
     wbFoldername.setLayoutData(fdbFoldername);
 
-    wFoldername = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wFoldername = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wFoldername );
     wFoldername.addModifyListener( lsMod );
     FormData fdFoldername = new FormData();
@@ -198,7 +198,7 @@ public class ActionFolderIsEmptyDialog extends ActionDialog implements IActionDi
     fdlWildcard.top = new FormAttachment( wSpecifyWildcard, margin );
     fdlWildcard.right = new FormAttachment( middle, -margin );
     wlWildcard.setLayoutData(fdlWildcard);
-    wWildcard = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wWildcard = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wWildcard );
     wWildcard.addModifyListener( lsMod );
     FormData fdWildcard = new FormData();
@@ -208,11 +208,11 @@ public class ActionFolderIsEmptyDialog extends ActionDialog implements IActionDi
     wWildcard.setLayoutData(fdWildcard);
 
     // Whenever something changes, set the tooltip to the expanded version:
-    wFoldername.addModifyListener( e -> wFoldername.setToolTipText( workflowMeta.environmentSubstitute( wFoldername.getText() ) ) );
+    wFoldername.addModifyListener( e -> wFoldername.setToolTipText( getWorkflowMeta().environmentSubstitute( wFoldername.getText() ) ) );
     // Whenever something changes, set the tooltip to the expanded version:
-    wWildcard.addModifyListener( e -> wWildcard.setToolTipText( workflowMeta.environmentSubstitute( wWildcard.getText() ) ) );
+    wWildcard.addModifyListener( e -> wWildcard.setToolTipText( getWorkflowMeta().environmentSubstitute( wWildcard.getText() ) ) );
 
-    wbFoldername.addListener(SWT.Selection, e-> BaseDialog.presentDirectoryDialog( shell, wFoldername, workflowMeta ));
+    wbFoldername.addListener(SWT.Selection, e-> BaseDialog.presentDirectoryDialog( shell, wFoldername, getWorkflowMeta() ));
 
     Button wOk = new Button(shell, SWT.PUSH);
     wOk.setText( BaseMessages.getString( PKG, "System.Button.OK" ) );

--- a/plugins/actions/folderisempty/src/test/java/org/apache/hop/workflow/actions/folderisempty/WorkflowActionFolderIsEmptyTest.java
+++ b/plugins/actions/folderisempty/src/test/java/org/apache/hop/workflow/actions/folderisempty/WorkflowActionFolderIsEmptyTest.java
@@ -25,7 +25,6 @@ package org.apache.hop.workflow.actions.folderisempty;
 import org.apache.hop.core.Const;
 import org.apache.hop.core.Result;
 import org.apache.hop.core.logging.HopLogStore;
-import org.apache.hop.workflow.Workflow;
 import org.apache.hop.workflow.WorkflowMeta;
 import org.apache.hop.workflow.action.ActionMeta;
 import org.apache.hop.workflow.engine.IWorkflowEngine;
@@ -45,9 +44,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
-public class WorkflowEntryFolderIsEmptyTest {
+public class WorkflowActionFolderIsEmptyTest {
   private IWorkflowEngine<WorkflowMeta> workflow;
-  private ActionFolderIsEmpty entry;
+  private ActionFolderIsEmpty action;
 
   private String emptyDir;
   private String nonEmptyDir;
@@ -64,12 +63,12 @@ public class WorkflowEntryFolderIsEmptyTest {
   @Before
   public void setUp() throws Exception {
     workflow = new LocalWorkflowEngine( new WorkflowMeta() );
-    entry = new ActionFolderIsEmpty();
+    action = new ActionFolderIsEmpty();
 
-    workflow.getWorkflowMeta().addAction( new ActionMeta( entry ) );
-    entry.setParentWorkflow( workflow );
+    workflow.getWorkflowMeta().addAction( new ActionMeta( action ) );
+    action.setParentWorkflow( workflow );
     WorkflowMeta mockWorkflowMeta = mock( WorkflowMeta.class );
-    entry.setParentWorkflowMeta( mockWorkflowMeta );
+    action.setParentWorkflowMeta( mockWorkflowMeta );
 
     workflow.setStopped( false );
 
@@ -91,9 +90,9 @@ public class WorkflowEntryFolderIsEmptyTest {
 
   @Test
   public void testSetNrErrorsSuccess() throws Exception {
-    entry.setFoldername( emptyDir );
+    action.setFoldername( emptyDir );
 
-    Result result = entry.execute( new Result(), 0 );
+    Result result = action.execute( new Result(), 0 );
 
     assertTrue( "For empty folder result should be true", result.getResult() );
     assertEquals( "There should be no errors", 0, result.getNrErrors() );
@@ -101,9 +100,9 @@ public class WorkflowEntryFolderIsEmptyTest {
 
   @Test
   public void testSetNrErrorsNewBehaviorFail() throws Exception {
-    entry.setFoldername( nonEmptyDir );
+    action.setFoldername( nonEmptyDir );
 
-    Result result = entry.execute( new Result(), 0 );
+    Result result = action.execute( new Result(), 0 );
 
     assertFalse( "For non-empty folder result should be false", result.getResult() );
     assertEquals( "There should be still no errors", 0, result.getNrErrors() );
@@ -111,11 +110,11 @@ public class WorkflowEntryFolderIsEmptyTest {
 
   @Test
   public void testSetNrErrorsOldBehaviorFail() throws Exception {
-    entry.setFoldername( nonEmptyDir );
+    action.setFoldername( nonEmptyDir );
 
-    entry.setVariable( Const.HOP_COMPATIBILITY_SET_ERROR_ON_SPECIFIC_WORKFLOW_ACTIONS, "Y" );
+    action.setVariable( Const.HOP_COMPATIBILITY_SET_ERROR_ON_SPECIFIC_WORKFLOW_ACTIONS, "Y" );
 
-    Result result = entry.execute( new Result(), 0 );
+    Result result = action.execute( new Result(), 0 );
 
     assertFalse( "For non-empty folder result should be false", result.getResult() );
     assertEquals( "According to old behaviour there should be an error", 1, result.getNrErrors() );

--- a/plugins/actions/folderscompare/src/main/java/org/apache/hop/workflow/actions/folderscompare/ActionFoldersCompareDialog.java
+++ b/plugins/actions/folderscompare/src/main/java/org/apache/hop/workflow/actions/folderscompare/ActionFoldersCompareDialog.java
@@ -79,7 +79,7 @@ public class ActionFoldersCompareDialog extends ActionDialog implements IActionD
   private Button wCompareFileSize;
 
   public ActionFoldersCompareDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionFoldersCompare) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "JobFoldersCompare.Name.Default" ) );
@@ -203,7 +203,7 @@ public class ActionFoldersCompareDialog extends ActionDialog implements IActionD
     fdlWildcard.right = new FormAttachment( middle, -margin );
     wlWildcard.setLayoutData(fdlWildcard);
     wWildcard =
-      new TextVar( workflowMeta, wSettings, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
+      new TextVar( getWorkflowMeta(), wSettings, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
         PKG, "JobFoldersCompare.Wildcard.Tooltip" ) );
     props.setLook( wWildcard );
     wWildcard.addModifyListener( lsMod );
@@ -289,7 +289,7 @@ public class ActionFoldersCompareDialog extends ActionDialog implements IActionD
 
     wbDirectory1.addSelectionListener(new SelectionAdapter() {
       public void widgetSelected( SelectionEvent e ) {
-        BaseDialog.presentDirectoryDialog( shell, wFilename1, workflowMeta );
+        BaseDialog.presentDirectoryDialog( shell, wFilename1, getWorkflowMeta() );
       }
     } );
 
@@ -302,7 +302,7 @@ public class ActionFoldersCompareDialog extends ActionDialog implements IActionD
     fdbFilename1.top = new FormAttachment(wSettings, 2 * margin );
     wbFilename1.setLayoutData(fdbFilename1);
 
-    wFilename1 = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wFilename1 = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wFilename1 );
     wFilename1.addModifyListener( lsMod );
     FormData fdFilename1 = new FormData();
@@ -312,9 +312,9 @@ public class ActionFoldersCompareDialog extends ActionDialog implements IActionD
     wFilename1.setLayoutData(fdFilename1);
 
     // Whenever something changes, set the tooltip to the expanded version:
-    wFilename1.addModifyListener( e -> wFilename1.setToolTipText( workflowMeta.environmentSubstitute( wFilename1.getText() ) ) );
+    wFilename1.addModifyListener( e -> wFilename1.setToolTipText( getWorkflowMeta().environmentSubstitute( wFilename1.getText() ) ) );
 
-    wbFilename1.addListener( SWT.Selection, e-> BaseDialog.presentFileDialog( shell, wFilename1, workflowMeta,
+    wbFilename1.addListener( SWT.Selection, e-> BaseDialog.presentFileDialog( shell, wFilename1, getWorkflowMeta(),
       new String[] { "*" }, FILETYPES, true )
     );
 
@@ -337,7 +337,7 @@ public class ActionFoldersCompareDialog extends ActionDialog implements IActionD
     fdbDirectory2.top = new FormAttachment( wFilename1, margin );
     wbDirectory2.setLayoutData(fdbDirectory2);
 
-    wbDirectory2.addListener( SWT.Selection, e-> BaseDialog.presentDirectoryDialog( shell, wFilename2, workflowMeta ) );
+    wbDirectory2.addListener( SWT.Selection, e-> BaseDialog.presentDirectoryDialog( shell, wFilename2, getWorkflowMeta() ) );
 
     // Browse files...
     Button wbFilename2 = new Button(shell, SWT.PUSH | SWT.CENTER);
@@ -348,7 +348,7 @@ public class ActionFoldersCompareDialog extends ActionDialog implements IActionD
     fdbFilename2.top = new FormAttachment( wFilename1, margin );
     wbFilename2.setLayoutData(fdbFilename2);
 
-    wFilename2 = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wFilename2 = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wFilename2 );
     wFilename2.addModifyListener( lsMod );
     FormData fdFilename2 = new FormData();
@@ -358,9 +358,9 @@ public class ActionFoldersCompareDialog extends ActionDialog implements IActionD
     wFilename2.setLayoutData(fdFilename2);
 
     // Whenever something changes, set the tooltip to the expanded version:
-    wFilename2.addModifyListener( e -> wFilename2.setToolTipText( workflowMeta.environmentSubstitute( wFilename2.getText() ) ) );
+    wFilename2.addModifyListener( e -> wFilename2.setToolTipText( getWorkflowMeta().environmentSubstitute( wFilename2.getText() ) ) );
 
-    wbFilename2.addListener( SWT.Selection, e-> BaseDialog.presentFileDialog( shell, wFilename2, workflowMeta,
+    wbFilename2.addListener( SWT.Selection, e-> BaseDialog.presentFileDialog( shell, wFilename2, getWorkflowMeta(),
       new String[] { "*" }, FILETYPES, true )
     );
 

--- a/plugins/actions/ftp/src/main/java/org/apache/hop/workflow/actions/ftp/ActionFtpDialog.java
+++ b/plugins/actions/ftp/src/main/java/org/apache/hop/workflow/actions/ftp/ActionFtpDialog.java
@@ -156,7 +156,7 @@ public class ActionFtpDialog extends ActionDialog implements IActionDialog {
   // }
 
   public ActionFtpDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionFtp) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "JobFTP.Name.Default" ) );
@@ -171,6 +171,8 @@ public class ActionFtpDialog extends ActionDialog implements IActionDialog {
     props.setLook( shell );
     WorkflowDialog.setShellImage( shell, action );
 
+    WorkflowMeta workflowMeta = getWorkflowMeta();
+    
     ModifyListener lsMod = e -> {
       pwdFolder = null;
       ftpclient = null;
@@ -1203,16 +1205,16 @@ public class ActionFtpDialog extends ActionDialog implements IActionDialog {
       if ( ftpclient == null || !ftpclient.connected() ) {
         // Create ftp client to host:port ...
         ftpclient = new FTPClient();
-        realServername = workflowMeta.environmentSubstitute( wServerName.getText() );
-        int realPort = Const.toInt( workflowMeta.environmentSubstitute( wPort.getText() ), 21 );
+        realServername = getWorkflowMeta().environmentSubstitute( wServerName.getText() );
+        int realPort = Const.toInt( getWorkflowMeta().environmentSubstitute( wPort.getText() ), 21 );
         ftpclient.setRemoteAddr( InetAddress.getByName( realServername ) );
         ftpclient.setRemotePort( realPort );
 
         if ( !Utils.isEmpty( wProxyHost.getText() ) ) {
-          String realProxy_host = workflowMeta.environmentSubstitute( wProxyHost.getText() );
+          String realProxy_host = getWorkflowMeta().environmentSubstitute( wProxyHost.getText() );
           ftpclient.setRemoteAddr( InetAddress.getByName( realProxy_host ) );
 
-          int port = Const.toInt( workflowMeta.environmentSubstitute( wProxyPort.getText() ), 21 );
+          int port = Const.toInt( getWorkflowMeta().environmentSubstitute( wProxyPort.getText() ), 21 );
           if ( port != 0 ) {
             ftpclient.setRemotePort( port );
           }
@@ -1221,15 +1223,15 @@ public class ActionFtpDialog extends ActionDialog implements IActionDialog {
         // login to ftp host ...
         ftpclient.connect();
         String realUsername =
-          workflowMeta.environmentSubstitute( wUserName.getText() )
+        		getWorkflowMeta().environmentSubstitute( wUserName.getText() )
             + ( !Utils.isEmpty( wProxyHost.getText() ) ? "@" + realServername : "" )
             + ( !Utils.isEmpty( wProxyUsername.getText() ) ? " "
-            + workflowMeta.environmentSubstitute( wProxyUsername.getText() ) : "" );
+            + getWorkflowMeta().environmentSubstitute( wProxyUsername.getText() ) : "" );
 
         String realPassword =
-          Utils.resolvePassword( workflowMeta, wPassword.getText() )
+          Utils.resolvePassword( getWorkflowMeta(), wPassword.getText() )
             + ( !Utils.isEmpty( wProxyPassword.getText() ) ? " "
-            + Utils.resolvePassword( workflowMeta, wProxyPassword.getText() ) : "" );
+            + Utils.resolvePassword( getWorkflowMeta(), wProxyPassword.getText() ) : "" );
         // login now ...
         ftpclient.login( realUsername, realPassword );
         pwdFolder = ftpclient.pwd();
@@ -1237,7 +1239,7 @@ public class ActionFtpDialog extends ActionDialog implements IActionDialog {
 
       String realFtpDirectory = "";
       if ( !Utils.isEmpty( wFtpDirectory.getText() ) ) {
-        realFtpDirectory = workflowMeta.environmentSubstitute( wFtpDirectory.getText() );
+        realFtpDirectory = getWorkflowMeta().environmentSubstitute( wFtpDirectory.getText() );
       }
 
       if ( checkfolder ) {
@@ -1257,7 +1259,7 @@ public class ActionFtpDialog extends ActionDialog implements IActionDialog {
         // move to folder ...
 
         if ( !Utils.isEmpty( wMoveToDirectory.getText() ) ) {
-          String realMoveDirectory = workflowMeta.environmentSubstitute( wMoveToDirectory.getText() );
+          String realMoveDirectory = getWorkflowMeta().environmentSubstitute( wMoveToDirectory.getText() );
           realMoveDirectory = realFtpDirectory + "/" + realMoveDirectory;
           ftpclient.chdir( realMoveDirectory );
         }

--- a/plugins/actions/ftp/src/main/java/org/apache/hop/workflow/actions/ftpdelete/ActionFtpDeleteDialog.java
+++ b/plugins/actions/ftp/src/main/java/org/apache/hop/workflow/actions/ftpdelete/ActionFtpDeleteDialog.java
@@ -140,7 +140,7 @@ public class ActionFtpDeleteDialog extends ActionDialog implements IActionDialog
     BaseMessages.getString( PKG, "JobFTPDelete.Filetype.All" ) };
 
   public ActionFtpDeleteDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionFtpDelete) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "JobFTPDelete.Name.Default" ) );
@@ -155,6 +155,8 @@ public class ActionFtpDeleteDialog extends ActionDialog implements IActionDialog
     props.setLook( shell );
     WorkflowDialog.setShellImage( shell, action );
 
+    WorkflowMeta workflowMeta = getWorkflowMeta();
+    
     ModifyListener lsMod = e -> {
       pwdFolder = null;
       ftpclient = null;
@@ -978,7 +980,7 @@ public class ActionFtpDeleteDialog extends ActionDialog implements IActionDialog
     boolean folderexists = false;
     String errmsg = "";
     try {
-      String realfoldername = workflowMeta.environmentSubstitute( wFtpDirectory.getText() );
+      String realfoldername = getWorkflowMeta().environmentSubstitute( wFtpDirectory.getText() );
       if ( !Utils.isEmpty( realfoldername ) ) {
         if ( connect() ) {
           if ( wProtocol.getText().equals( ActionFtpDelete.PROTOCOL_FTP ) ) {
@@ -1055,6 +1057,8 @@ public class ActionFtpDeleteDialog extends ActionDialog implements IActionDialog
     boolean retval = false;
     String realServername = null;
     try {
+      WorkflowMeta workflowMeta = getWorkflowMeta();
+      
       if ( ftpclient == null || !ftpclient.connected() ) {
         // Create ftp client to host:port ...
         ftpclient = new FTPClient();
@@ -1112,6 +1116,8 @@ public class ActionFtpDeleteDialog extends ActionDialog implements IActionDialog
   private boolean connectToFtps() {
     boolean retval = false;
     try {
+      WorkflowMeta workflowMeta = getWorkflowMeta();
+    	
       if ( ftpsclient == null ) {
         String realServername = workflowMeta.environmentSubstitute( wServerName.getText() );
         String realUsername = workflowMeta.environmentSubstitute( wUserName.getText() );
@@ -1168,6 +1174,9 @@ public class ActionFtpDeleteDialog extends ActionDialog implements IActionDialog
   private boolean connectToSftp() {
     boolean retval = false;
     try {
+    	
+      WorkflowMeta workflowMeta = getWorkflowMeta();
+      
       if ( sftpclient == null ) {
         // Create sftp client to host ...
         sftpclient =
@@ -1202,6 +1211,9 @@ public class ActionFtpDeleteDialog extends ActionDialog implements IActionDialog
   private boolean connectToSSH() {
     boolean retval = false;
     try {
+    	
+      WorkflowMeta workflowMeta = getWorkflowMeta();
+    	
       if ( conn == null ) { // Create a connection instance
         conn =
           new Connection( workflowMeta.environmentSubstitute( wServerName.getText() ), Const.toInt( workflowMeta

--- a/plugins/actions/ftp/src/main/java/org/apache/hop/workflow/actions/ftpput/ActionFtpPutDialog.java
+++ b/plugins/actions/ftp/src/main/java/org/apache/hop/workflow/actions/ftpput/ActionFtpPutDialog.java
@@ -110,7 +110,7 @@ public class ActionFtpPutDialog extends ActionDialog implements IActionDialog {
   private String pwdFolder = null;
 
   public ActionFtpPutDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionFtpPut) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "JobFTPPUT.Name.Default" ) );
@@ -125,6 +125,8 @@ public class ActionFtpPutDialog extends ActionDialog implements IActionDialog {
     props.setLook( shell );
     WorkflowDialog.setShellImage( shell, action );
 
+    WorkflowMeta workflowMeta = getWorkflowMeta();
+    
     ModifyListener lsMod = e -> {
       ftpclient = null;
       pwdFolder = null;
@@ -826,6 +828,8 @@ public class ActionFtpPutDialog extends ActionDialog implements IActionDialog {
     boolean retval = false;
     String realServername = null;
     try {
+      WorkflowMeta workflowMeta = getWorkflowMeta();
+    	
       if ( ftpclient == null || !ftpclient.connected() ) {
         // Create ftp client to host:port ...
         ftpclient = new FTPClient();

--- a/plugins/actions/ftp/src/main/java/org/apache/hop/workflow/actions/ftpsget/ActionFtpsGetDialog.java
+++ b/plugins/actions/ftp/src/main/java/org/apache/hop/workflow/actions/ftpsget/ActionFtpsGetDialog.java
@@ -136,7 +136,7 @@ public class ActionFtpsGetDialog extends ActionDialog implements IActionDialog {
   private FtpsConnection connection = null;
 
   public ActionFtpsGetDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionFtpsGet) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "JobFTPS.Name.Default" ) );
@@ -151,6 +151,8 @@ public class ActionFtpsGetDialog extends ActionDialog implements IActionDialog {
     props.setLook( shell );
     WorkflowDialog.setShellImage( shell, action );
 
+    WorkflowMeta workflowMeta = getWorkflowMeta();
+    
     ModifyListener lsMod = e -> {
       // pwdFolder=null;
       connection = null;
@@ -1102,6 +1104,8 @@ public class ActionFtpsGetDialog extends ActionDialog implements IActionDialog {
     boolean retval = true;
     String realServername = null;
     try {
+      WorkflowMeta workflowMeta = getWorkflowMeta();
+    	
       if ( connection == null ) {
         // Create FTPS client to host:port ...
         realServername = workflowMeta.environmentSubstitute( wServerName.getText() );

--- a/plugins/actions/ftp/src/main/java/org/apache/hop/workflow/actions/ftpsput/ActionFtpsPutDialog.java
+++ b/plugins/actions/ftp/src/main/java/org/apache/hop/workflow/actions/ftpsput/ActionFtpsPutDialog.java
@@ -102,7 +102,7 @@ public class ActionFtpsPutDialog extends ActionDialog implements IActionDialog {
   private FtpsConnection connection = null;
 
   public ActionFtpsPutDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionFtpsPut) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "JobFTPSPUT.Name.Default" ) );
@@ -117,6 +117,8 @@ public class ActionFtpsPutDialog extends ActionDialog implements IActionDialog {
     props.setLook( shell );
     WorkflowDialog.setShellImage( shell, action );
 
+    WorkflowMeta workflowMeta = getWorkflowMeta();
+    
     ModifyListener lsMod = e -> {
       connection = null;
       action.setChanged();
@@ -720,6 +722,8 @@ public class ActionFtpsPutDialog extends ActionDialog implements IActionDialog {
   private boolean connectToFtp(boolean checkfolder, String remoteFoldername ) {
     String realServername = null;
     try {
+      WorkflowMeta workflowMeta = getWorkflowMeta();
+    	
       realServername = workflowMeta.environmentSubstitute( wServerName.getText() );
       int realPort = Const.toInt( workflowMeta.environmentSubstitute( wServerPort.getText() ), 0 );
       String realUsername = workflowMeta.environmentSubstitute( wUserName.getText() );

--- a/plugins/actions/ftp/src/main/java/org/apache/hop/workflow/actions/sftp/ActionSftpDialog.java
+++ b/plugins/actions/ftp/src/main/java/org/apache/hop/workflow/actions/sftp/ActionSftpDialog.java
@@ -116,7 +116,7 @@ public class ActionSftpDialog extends ActionDialog implements IActionDialog {
   private LabelTextVar wProxyPassword;
 
   public ActionSftpDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionSftp) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "JobSFTP.Name.Default" ) );
@@ -130,7 +130,9 @@ public class ActionSftpDialog extends ActionDialog implements IActionDialog {
     shell = new Shell( parent, SWT.DIALOG_TRIM | SWT.MIN | SWT.MAX | SWT.RESIZE );
     props.setLook( shell );
     WorkflowDialog.setShellImage( shell, action );
-
+    
+    WorkflowMeta workflowMeta = getWorkflowMeta();
+    
     ModifyListener lsMod = e -> {
       sftpclient = null;
       action.setChanged();
@@ -786,6 +788,8 @@ public class ActionSftpDialog extends ActionDialog implements IActionDialog {
   private boolean connectToSftp(boolean checkFolder, String Remotefoldername ) {
     boolean retval = false;
     try {
+      WorkflowMeta workflowMeta = getWorkflowMeta();
+    	
       if ( sftpclient == null ) {
         // Create sftp client to host ...
         sftpclient = new SftpClient(
@@ -835,7 +839,7 @@ public class ActionSftpDialog extends ActionDialog implements IActionDialog {
   }
 
   private void checkRemoteFolder() {
-    String changeFtpFolder = workflowMeta.environmentSubstitute( wScpDirectory.getText() );
+    String changeFtpFolder = getWorkflowMeta().environmentSubstitute( wScpDirectory.getText() );
     if ( !Utils.isEmpty( changeFtpFolder ) ) {
       if ( connectToSftp( true, changeFtpFolder ) ) {
         MessageBox mb = new MessageBox( shell, SWT.OK | SWT.ICON_INFORMATION );

--- a/plugins/actions/ftp/src/main/java/org/apache/hop/workflow/actions/sftpput/ActionSftpPutDialog.java
+++ b/plugins/actions/ftp/src/main/java/org/apache/hop/workflow/actions/sftpput/ActionSftpPutDialog.java
@@ -133,7 +133,7 @@ public class ActionSftpPutDialog extends ActionDialog implements IActionDialog {
   private SftpClient sftpclient = null;
 
   public ActionSftpPutDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionSftpPut) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "JobSFTPPUT.Title" ) );
@@ -148,6 +148,8 @@ public class ActionSftpPutDialog extends ActionDialog implements IActionDialog {
     props.setLook( shell );
     WorkflowDialog.setShellImage( shell, action );
 
+    WorkflowMeta workflowMeta = getWorkflowMeta();
+    
     ModifyListener lsMod = e -> {
       sftpclient = null;
       action.setChanged();
@@ -937,6 +939,8 @@ public class ActionSftpPutDialog extends ActionDialog implements IActionDialog {
   private boolean connectToSftp(boolean checkFolder, String Remotefoldername ) {
     boolean retval = false;
     try {
+      WorkflowMeta workflowMeta = getWorkflowMeta();
+    	
       if ( sftpclient == null ) {
         // Create sftp client to host ...
         sftpclient = new SftpClient(
@@ -986,7 +990,7 @@ public class ActionSftpPutDialog extends ActionDialog implements IActionDialog {
   }
 
   private void checkRemoteFolder() {
-    String changeFtpFolder = workflowMeta.environmentSubstitute( wScpDirectory.getText() );
+    String changeFtpFolder = getWorkflowMeta().environmentSubstitute( wScpDirectory.getText() );
     if ( !Utils.isEmpty( changeFtpFolder ) ) {
       if ( connectToSftp( true, changeFtpFolder ) ) {
         MessageBox mb = new MessageBox( shell, SWT.OK | SWT.ICON_INFORMATION );

--- a/plugins/actions/ftp/src/test/java/org/apache/hop/workflow/actions/ftp/WorkflowActionFtpTest.java
+++ b/plugins/actions/ftp/src/test/java/org/apache/hop/workflow/actions/ftp/WorkflowActionFtpTest.java
@@ -22,14 +22,23 @@
 
 package org.apache.hop.workflow.actions.ftp;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.regex.Pattern;
+
 import org.apache.hop.core.Const;
 import org.apache.hop.core.HopClientEnvironment;
 import org.apache.hop.core.Result;
-import org.apache.hop.workflow.Workflow;
-import org.apache.hop.workflow.WorkflowMeta;
-import org.apache.hop.workflow.action.ActionMeta;
 import org.apache.hop.junit.rules.RestoreHopEngineEnvironment;
 import org.apache.hop.utils.TestUtils;
+import org.apache.hop.workflow.WorkflowMeta;
+import org.apache.hop.workflow.action.ActionMeta;
 import org.apache.hop.workflow.engine.IWorkflowEngine;
 import org.apache.hop.workflow.engines.local.LocalWorkflowEngine;
 import org.junit.After;
@@ -40,19 +49,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import java.io.File;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.regex.Pattern;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
-public class WorkflowEntryFtpTest {
+public class WorkflowActionFtpTest {
   private IWorkflowEngine<WorkflowMeta> workflow;
-  private ActionFtp entry;
+  private ActionFtp action;
   private String existingDir;
   @ClassRule public static RestoreHopEngineEnvironment env = new RestoreHopEngineEnvironment();
 
@@ -67,19 +66,19 @@ public class WorkflowEntryFtpTest {
   @Before
   public void setUp() throws Exception {
     workflow = new LocalWorkflowEngine( new WorkflowMeta() );
-    entry = new MockedActionFtp();
+    action = new MockedActionFtp();
 
-    workflow.getWorkflowMeta().addAction( new ActionMeta( entry ) );
-    entry.setParentWorkflow( workflow );
+    workflow.getWorkflowMeta().addAction( new ActionMeta( action ) );
+    action.setParentWorkflow( workflow );
 
     workflow.setStopped( false );
 
-    entry.setServerName( "some.server" );
-    entry.setUserName( "anonymous" );
-    entry.setFtpDirectory( "." );
-    entry.setWildcard( "robots.txt" );
-    entry.setBinaryMode( false );
-    entry.setSuccessCondition( "success_if_no_errors" );
+    action.setServerName( "some.server" );
+    action.setUserName( "anonymous" );
+    action.setFtpDirectory( "." );
+    action.setWildcard( "robots.txt" );
+    action.setBinaryMode( false );
+    action.setSuccessCondition( "success_if_no_errors" );
 
     existingDir = TestUtils.createTempDir();
   }
@@ -100,9 +99,9 @@ public class WorkflowEntryFtpTest {
 
   @Test
   public void testFixedExistingTargetDir() throws Exception {
-    entry.setTargetDirectory( existingDir );
+    action.setTargetDirectory( existingDir );
 
-    Result result = entry.execute( new Result(), 0 );
+    Result result = action.execute( new Result(), 0 );
 
     assertTrue( "For existing folder should be true", result.getResult() );
     assertEquals( "There should be no errors", 0, result.getNrErrors() );
@@ -110,9 +109,9 @@ public class WorkflowEntryFtpTest {
 
   @Test
   public void testFixedNonExistingTargetDir() throws Exception {
-    entry.setTargetDirectory( existingDir + File.separator + "sub" );
+    action.setTargetDirectory( existingDir + File.separator + "sub" );
 
-    Result result = entry.execute( new Result(), 0 );
+    Result result = action.execute( new Result(), 0 );
 
     assertFalse( "For non existing folder should be false", result.getResult() );
     assertTrue( "There should be errors", 0 != result.getNrErrors() );
@@ -120,10 +119,10 @@ public class WorkflowEntryFtpTest {
 
   @Test
   public void testVariableExistingTargetDir() throws Exception {
-    entry.setTargetDirectory( "${Internal.Workflow.Filename.Directory}" );
-    entry.setVariable( "Internal.Workflow.Filename.Directory", existingDir );
+    action.setTargetDirectory( "${Internal.Workflow.Filename.Directory}" );
+    action.setVariable( "Internal.Workflow.Filename.Directory", existingDir );
 
-    Result result = entry.execute( new Result(), 0 );
+    Result result = action.execute( new Result(), 0 );
 
     assertTrue( "For existing folder should be true", result.getResult() );
     assertEquals( "There should be no errors", 0, result.getNrErrors() );
@@ -131,10 +130,10 @@ public class WorkflowEntryFtpTest {
 
   @Test
   public void testVariableNonExistingTargetDir() throws Exception {
-    entry.setTargetDirectory( "${Internal.Workflow.Filename.Directory}/Worg" );
-    entry.setVariable( "Internal.Workflow.Filename.Directory", existingDir + File.separator + "sub" );
+    action.setTargetDirectory( "${Internal.Workflow.Filename.Directory}/Worg" );
+    action.setVariable( "Internal.Workflow.Filename.Directory", existingDir + File.separator + "sub" );
 
-    Result result = entry.execute( new Result(), 0 );
+    Result result = action.execute( new Result(), 0 );
 
     assertFalse( "For non existing folder should be false", result.getResult() );
     assertTrue( "There should be errors", 0 != result.getNrErrors() );
@@ -142,10 +141,10 @@ public class WorkflowEntryFtpTest {
 
   @Test
   public void testProtocolVariableExistingTargetDir() throws Exception {
-    entry.setTargetDirectory( "${Internal.Workflow.Filename.Directory}" );
-    entry.setVariable( "Internal.Workflow.Filename.Directory", "file://" + existingDir );
+    action.setTargetDirectory( "${Internal.Workflow.Filename.Directory}" );
+    action.setVariable( "Internal.Workflow.Filename.Directory", "file://" + existingDir );
 
-    Result result = entry.execute( new Result(), 0 );
+    Result result = action.execute( new Result(), 0 );
 
     assertTrue( "For existing folder should be true", result.getResult() );
     assertEquals( "There should be no errors", 0, result.getNrErrors() );
@@ -153,10 +152,10 @@ public class WorkflowEntryFtpTest {
 
   @Test
   public void testPtotocolVariableNonExistingTargetDir() throws Exception {
-    entry.setTargetDirectory( "${Internal.Workflow.Filename.Directory}/Worg" );
-    entry.setVariable( "Internal.Workflow.Filename.Directory", "file://" + existingDir + File.separator + "sub" );
+    action.setTargetDirectory( "${Internal.Workflow.Filename.Directory}/Worg" );
+    action.setVariable( "Internal.Workflow.Filename.Directory", "file://" + existingDir + File.separator + "sub" );
 
-    Result result = entry.execute( new Result(), 0 );
+    Result result = action.execute( new Result(), 0 );
 
     assertFalse( "For non existing folder should be false", result.getResult() );
     assertTrue( "There should be errors", 0 != result.getNrErrors() );

--- a/plugins/actions/ftp/src/test/java/org/apache/hop/workflow/actions/ftpput/WorkflowActionFtpPutTest.java
+++ b/plugins/actions/ftp/src/test/java/org/apache/hop/workflow/actions/ftpput/WorkflowActionFtpPutTest.java
@@ -42,7 +42,7 @@ import static org.mockito.Mockito.verify;
 /**
  * @author Andrey Khayrutdinov
  */
-public class WorkflowEntryFtpPutTest {
+public class WorkflowActionFtpPutTest {
 
   private ActionFtpPut entry;
   private FTPClient ftpClient;

--- a/plugins/actions/getpop/src/main/java/org/apache/hop/workflow/actions/getpop/ActionGetPOPDialog.java
+++ b/plugins/actions/getpop/src/main/java/org/apache/hop/workflow/actions/getpop/ActionGetPOPDialog.java
@@ -212,7 +212,7 @@ public class ActionGetPOPDialog extends ActionDialog implements IActionDialog {
   private MailConnection mailConn = null;
 
   public ActionGetPOPDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionGetPOP) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "JobGetPOP.Name.Default" ) );
@@ -227,6 +227,8 @@ public class ActionGetPOPDialog extends ActionDialog implements IActionDialog {
     props.setLook( shell );
     WorkflowDialog.setShellImage( shell, action );
 
+    WorkflowMeta workflowMeta = getWorkflowMeta();
+    
     ModifyListener lsMod = e -> {
       closeMailConnection();
       action.setChanged();
@@ -1520,11 +1522,11 @@ public class ActionGetPOPDialog extends ActionDialog implements IActionDialog {
     }
 
     if ( !retval ) {
-      String realserver = workflowMeta.environmentSubstitute( wServerName.getText() );
-      String realuser = workflowMeta.environmentSubstitute( wUserName.getText() );
-      String realpass = action.getRealPassword( workflowMeta.environmentSubstitute( wPassword.getText() ) );
-      int realport = Const.toInt( workflowMeta.environmentSubstitute( wPort.getText() ), -1 );
-      String realproxyuser = workflowMeta.environmentSubstitute( wProxyUsername.getText() );
+      String realserver = getWorkflowMeta().environmentSubstitute( wServerName.getText() );
+      String realuser = getWorkflowMeta().environmentSubstitute( wUserName.getText() );
+      String realpass = action.getRealPassword( getWorkflowMeta().environmentSubstitute( wPassword.getText() ) );
+      int realport = Const.toInt( getWorkflowMeta().environmentSubstitute( wPort.getText() ), -1 );
+      String realproxyuser = getWorkflowMeta().environmentSubstitute( wProxyUsername.getText() );
       try {
         mailConn =
           new MailConnection(

--- a/plugins/actions/http/src/main/java/org/apache/hop/workflow/actions/http/ActionHttpDialog.java
+++ b/plugins/actions/http/src/main/java/org/apache/hop/workflow/actions/http/ActionHttpDialog.java
@@ -124,7 +124,7 @@ public class ActionHttpDialog extends ActionDialog implements IActionDialog {
   private boolean changed;
 
   public ActionHttpDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionHttp) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "JobHTTP.Name.Default" ) );
@@ -139,6 +139,8 @@ public class ActionHttpDialog extends ActionDialog implements IActionDialog {
     props.setLook( shell );
     WorkflowDialog.setShellImage( shell, action );
 
+    WorkflowMeta workflowMeta = getWorkflowMeta();
+    
     ModifyListener lsMod = e -> action.setChanged();
     changed = action.hasChanged();
 

--- a/plugins/actions/mail/src/main/java/org/apache/hop/workflow/actions/mail/ActionMailDialog.java
+++ b/plugins/actions/mail/src/main/java/org/apache/hop/workflow/actions/mail/ActionMailDialog.java
@@ -146,7 +146,7 @@ public class ActionMailDialog extends ActionDialog implements IActionDialog {
   private TableView wFields;
 
   public ActionMailDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionMail) action;
   }
 
@@ -158,6 +158,8 @@ public class ActionMailDialog extends ActionDialog implements IActionDialog {
     props.setLook( shell );
     WorkflowDialog.setShellImage( shell, action );
 
+    WorkflowMeta workflowMeta = getWorkflowMeta();
+       
     ModifyListener lsMod = e -> action.setChanged();
     backupChanged = action.hasChanged();
     backupDate = action.getIncludeDate();

--- a/plugins/actions/mailvalidator/src/main/java/org/apache/hop/workflow/actions/mailvalidator/ActionMailValidatorDialog.java
+++ b/plugins/actions/mailvalidator/src/main/java/org/apache/hop/workflow/actions/mailvalidator/ActionMailValidatorDialog.java
@@ -66,7 +66,7 @@ public class ActionMailValidatorDialog extends ActionDialog implements IActionDi
   private Button wSMTPCheck;
 
   public ActionMailValidatorDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionMailValidator) action;
 
     if ( this.action.getName() == null ) {
@@ -114,7 +114,7 @@ public class ActionMailValidatorDialog extends ActionDialog implements IActionDi
     wName.setLayoutData(fdName);
 
     // eMail address
-    wMailAddress = new LabelTextVar( workflowMeta, shell,
+    wMailAddress = new LabelTextVar( getWorkflowMeta(), shell,
       BaseMessages.getString( PKG, "ActionMailValidatorDialog.MailAddress.Label" ),
       BaseMessages.getString( PKG, "ActionMailValidatorDialog.MailAddress.Tooltip" ) );
     wMailAddress.addModifyListener( lsMod );
@@ -170,7 +170,7 @@ public class ActionMailValidatorDialog extends ActionDialog implements IActionDi
     fdlTimeOut.top = new FormAttachment( wSMTPCheck, margin );
     wlTimeOut.setLayoutData(fdlTimeOut);
 
-    wTimeOut = new TextVar( workflowMeta, wSettingsGroup, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wTimeOut = new TextVar( getWorkflowMeta(), wSettingsGroup, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     wTimeOut.setToolTipText( BaseMessages.getString( PKG, "ActionMailValidatorDialog.TimeOutField.Tooltip" ) );
     props.setLook( wTimeOut );
     wTimeOut.addModifyListener( lsMod );
@@ -190,7 +190,7 @@ public class ActionMailValidatorDialog extends ActionDialog implements IActionDi
     fdleMailSender.top = new FormAttachment( wTimeOut, margin );
     wleMailSender.setLayoutData(fdleMailSender);
 
-    weMailSender = new TextVar( workflowMeta, wSettingsGroup, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    weMailSender = new TextVar( getWorkflowMeta(), wSettingsGroup, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     weMailSender.setToolTipText( BaseMessages.getString(
       PKG, "ActionMailValidatorDialog.eMailSenderField.Tooltip" ) );
     props.setLook( weMailSender );
@@ -211,7 +211,7 @@ public class ActionMailValidatorDialog extends ActionDialog implements IActionDi
     fdlDefaultSMTP.top = new FormAttachment( weMailSender, margin );
     wlDefaultSMTP.setLayoutData(fdlDefaultSMTP);
 
-    wDefaultSMTP = new TextVar( workflowMeta, wSettingsGroup, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wDefaultSMTP = new TextVar( getWorkflowMeta(), wSettingsGroup, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     wDefaultSMTP.setToolTipText( BaseMessages.getString(
       PKG, "ActionMailValidatorDialog.DefaultSMTPField.Tooltip" ) );
     props.setLook( wDefaultSMTP );

--- a/plugins/actions/movefiles/src/main/java/org/apache/hop/workflow/actions/movefiles/ActionMoveFilesDialog.java
+++ b/plugins/actions/movefiles/src/main/java/org/apache/hop/workflow/actions/movefiles/ActionMoveFilesDialog.java
@@ -152,7 +152,7 @@ public class ActionMoveFilesDialog extends ActionDialog implements IActionDialog
   private Button wSimulate;
 
   public ActionMoveFilesDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionMoveFiles) action;
 
     if ( this.action.getName() == null ) {
@@ -168,6 +168,8 @@ public class ActionMoveFilesDialog extends ActionDialog implements IActionDialog
     props.setLook( shell );
     WorkflowDialog.setShellImage( shell, action );
 
+    WorkflowMeta workflowMeta = getWorkflowMeta();
+    
     ModifyListener lsMod = e -> action.setChanged();
     changed = action.hasChanged();
 

--- a/plugins/actions/msgboxinfo/src/main/java/org/apache/hop/workflow/actions/msgboxinfo/ActionMsgBoxInfoDialog.java
+++ b/plugins/actions/msgboxinfo/src/main/java/org/apache/hop/workflow/actions/msgboxinfo/ActionMsgBoxInfoDialog.java
@@ -64,7 +64,7 @@ public class ActionMsgBoxInfoDialog extends ActionDialog implements IActionDialo
   private TextVar wTitleMessage;
 
   public ActionMsgBoxInfoDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionMsgBoxInfo) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "MsgBoxInfo.Name.Default" ) );
@@ -129,7 +129,7 @@ public class ActionMsgBoxInfoDialog extends ActionDialog implements IActionDialo
     fdlTitleMessage.right = new FormAttachment( middle, -margin );
     wlTitleMessage.setLayoutData(fdlTitleMessage);
 
-    wTitleMessage = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wTitleMessage = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wTitleMessage );
     wTitleMessage.addModifyListener( lsMod );
     FormData fdTitleMessage = new FormData();
@@ -148,7 +148,7 @@ public class ActionMsgBoxInfoDialog extends ActionDialog implements IActionDialo
     fdlBodyMessage.right = new FormAttachment( middle, -margin );
     wlBodyMessage.setLayoutData(fdlBodyMessage);
 
-    wBodyMessage = new TextVar( workflowMeta, shell, SWT.MULTI | SWT.LEFT | SWT.BORDER | SWT.H_SCROLL | SWT.V_SCROLL );
+    wBodyMessage = new TextVar( getWorkflowMeta(), shell, SWT.MULTI | SWT.LEFT | SWT.BORDER | SWT.H_SCROLL | SWT.V_SCROLL );
     wBodyMessage.setText( BaseMessages.getString( PKG, "MsgBoxInfo.Name.Default" ) );
     props.setLook( wBodyMessage, Props.WIDGET_STYLE_FIXED );
     wBodyMessage.addModifyListener( lsMod );
@@ -160,7 +160,7 @@ public class ActionMsgBoxInfoDialog extends ActionDialog implements IActionDialo
     wBodyMessage.setLayoutData(fdBodyMessage);
 
     // SelectionAdapter lsVar = VariableButtonListenerFactory.getSelectionAdapter(shell, wBodyMessage, workflowMeta);
-    wBodyMessage.addKeyListener( new ControlSpaceKeyAdapter( workflowMeta, wBodyMessage ) );
+    wBodyMessage.addKeyListener( new ControlSpaceKeyAdapter( getWorkflowMeta(), wBodyMessage ) );
 
     // Add listeners
     Listener lsCancel = e -> cancel();

--- a/plugins/actions/mssqlbulkload/src/main/java/org/apache/hop/workflow/actions/mssqlbulkload/ActionMssqlBulkLoadDialog.java
+++ b/plugins/actions/mssqlbulkload/src/main/java/org/apache/hop/workflow/actions/mssqlbulkload/ActionMssqlBulkLoadDialog.java
@@ -133,7 +133,7 @@ public class ActionMssqlBulkLoadDialog extends ActionDialog implements IActionDi
   private TextVar wRowsPerBatch;
 
   public ActionMssqlBulkLoadDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionMssqlBulkLoad) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "JobMssqlBulkLoad.Name.Default" ) );
@@ -147,7 +147,9 @@ public class ActionMssqlBulkLoadDialog extends ActionDialog implements IActionDi
     shell = new Shell( parent, SWT.DIALOG_TRIM | SWT.MIN | SWT.MAX | SWT.RESIZE );
     props.setLook( shell );
     WorkflowDialog.setShellImage( shell, action );
-
+    
+    WorkflowMeta workflowMeta = getWorkflowMeta();
+    
     ModifyListener lsMod = e -> action.setChanged();
     changed = action.hasChanged();
 
@@ -1112,7 +1114,7 @@ public class ActionMssqlBulkLoadDialog extends ActionDialog implements IActionDi
       return;
     }
     action.setName( wName.getText() );
-    action.setDatabase( workflowMeta.findDatabase( wConnection.getText() ) );
+    action.setDatabase( getWorkflowMeta().findDatabase( wConnection.getText() ) );
     action.setSchemaname( wSchemaname.getText() );
     action.setTablename( wTablename.getText() );
     action.setFilename( wFilename.getText() );
@@ -1156,9 +1158,10 @@ public class ActionMssqlBulkLoadDialog extends ActionDialog implements IActionDi
     if ( StringUtils.isEmpty( connectionName ) ) {
       return;
     }
-    DatabaseMeta databaseMeta = workflowMeta.findDatabase( connectionName );
+        
+    DatabaseMeta databaseMeta = getWorkflowMeta().findDatabase( connectionName );
     if ( databaseMeta != null ) {
-      DatabaseExplorerDialog std = new DatabaseExplorerDialog( shell, SWT.NONE, databaseMeta, workflowMeta.getDatabases() );
+      DatabaseExplorerDialog std = new DatabaseExplorerDialog( shell, SWT.NONE, databaseMeta, getWorkflowMeta().getDatabases() );
       std.setSelectedSchemaAndTable( wSchemaname.getText(), wTablename.getText() );
       if ( std.open() ) {
         wTablename.setText( Const.NVL( std.getTableName(), "" ) );
@@ -1176,10 +1179,10 @@ public class ActionMssqlBulkLoadDialog extends ActionDialog implements IActionDi
    */
   private void getListColumns() {
     if ( !Utils.isEmpty( wTablename.getText() ) ) {
-      DatabaseMeta databaseMeta = workflowMeta.findDatabase( wConnection.getText() );
+      DatabaseMeta databaseMeta = getWorkflowMeta().findDatabase( wConnection.getText() );
       if ( databaseMeta != null ) {
         Database database = new Database( loggingObject, databaseMeta );
-        database.shareVariablesWith( workflowMeta );
+        database.shareVariablesWith( getWorkflowMeta() );
         try {
           database.connect();
           IRowMeta row =

--- a/plugins/actions/mysqlbulkfile/src/main/java/org/apache/hop/workflow/actions/mysqlbulkfile/ActionMysqlBulkFileDialog.java
+++ b/plugins/actions/mysqlbulkfile/src/main/java/org/apache/hop/workflow/actions/mysqlbulkfile/ActionMysqlBulkFileDialog.java
@@ -106,7 +106,7 @@ public class ActionMysqlBulkFileDialog extends ActionDialog implements IActionDi
   private Button wAddFileToResult;
 
   public ActionMysqlBulkFileDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionMysqlBulkFile) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "JobMysqlBulkFile.Name.Default" ) );
@@ -120,7 +120,9 @@ public class ActionMysqlBulkFileDialog extends ActionDialog implements IActionDi
     shell = new Shell( parent, SWT.DIALOG_TRIM | SWT.MIN | SWT.MAX | SWT.RESIZE );
     props.setLook( shell );
     WorkflowDialog.setShellImage( shell, action );
-
+    
+    WorkflowMeta workflowMeta = getWorkflowMeta();
+    
     ModifyListener lsMod = e -> action.setChanged();
     changed = action.hasChanged();
 
@@ -669,7 +671,7 @@ public class ActionMysqlBulkFileDialog extends ActionDialog implements IActionDi
       return;
     }
     action.setName( wName.getText() );
-    action.setDatabase( workflowMeta.findDatabase( wConnection.getText() ) );
+    action.setDatabase( getWorkflowMeta().findDatabase( wConnection.getText() ) );
     action.setSchemaname( wSchemaname.getText() );
     action.setTablename( wTablename.getText() );
     action.setFilename( wFilename.getText() );
@@ -694,9 +696,9 @@ public class ActionMysqlBulkFileDialog extends ActionDialog implements IActionDi
   private void getTableName() {
     String databaseName = wConnection.getText();
     if ( StringUtils.isNotEmpty( databaseName ) ) {
-      DatabaseMeta databaseMeta = workflowMeta.findDatabase( databaseName );
+      DatabaseMeta databaseMeta = getWorkflowMeta().findDatabase( databaseName );
       if ( databaseMeta != null ) {
-        DatabaseExplorerDialog std = new DatabaseExplorerDialog( shell, SWT.NONE, databaseMeta, workflowMeta.getDatabases() );
+        DatabaseExplorerDialog std = new DatabaseExplorerDialog( shell, SWT.NONE, databaseMeta, getWorkflowMeta().getDatabases() );
         std.setSelectedSchemaAndTable( wSchemaname.getText(), wTablename.getText() );
         if ( std.open() ) {
           // wSchemaname.setText(Const.NVL(std.getSchemaName(), ""));
@@ -716,10 +718,10 @@ public class ActionMysqlBulkFileDialog extends ActionDialog implements IActionDi
    */
   private void getListColumns() {
     if ( !Utils.isEmpty( wTablename.getText() ) ) {
-      DatabaseMeta databaseMeta = workflowMeta.findDatabase( wConnection.getText() );
+      DatabaseMeta databaseMeta = getWorkflowMeta().findDatabase( wConnection.getText() );
       if ( databaseMeta != null ) {
         Database database = new Database( loggingObject, databaseMeta );
-        database.shareVariablesWith( workflowMeta );
+        database.shareVariablesWith( getWorkflowMeta() );
         try {
           database.connect();
           IRowMeta row =

--- a/plugins/actions/mysqlbulkload/src/main/java/org/apache/hop/workflow/actions/mysqlbulkload/ActionMysqlBulkLoadDialog.java
+++ b/plugins/actions/mysqlbulkload/src/main/java/org/apache/hop/workflow/actions/mysqlbulkload/ActionMysqlBulkLoadDialog.java
@@ -103,7 +103,7 @@ public class ActionMysqlBulkLoadDialog extends ActionDialog implements IActionDi
   private Button wAddFileToResult;
 
   public ActionMysqlBulkLoadDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionMysqlBulkLoad) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "JobMysqlBulkLoad.Name.Default" ) );
@@ -163,7 +163,7 @@ public class ActionMysqlBulkLoadDialog extends ActionDialog implements IActionDi
     fdlSchemaname.top = new FormAttachment( wConnection, margin );
     wlSchemaname.setLayoutData(fdlSchemaname);
 
-    wSchemaname = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wSchemaname = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wSchemaname );
     wSchemaname.setToolTipText( BaseMessages.getString( PKG, "JobMysqlBulkLoad.Schemaname.Tooltip" ) );
     wSchemaname.addModifyListener( lsMod );
@@ -196,7 +196,7 @@ public class ActionMysqlBulkLoadDialog extends ActionDialog implements IActionDi
       }
     } );
 
-    wTablename = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wTablename = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wTablename );
     wTablename.addModifyListener( lsMod );
     FormData fdTablename = new FormData();
@@ -224,7 +224,7 @@ public class ActionMysqlBulkLoadDialog extends ActionDialog implements IActionDi
     fdbFilename.top = new FormAttachment( wTablename, 0 );
     wbFilename.setLayoutData(fdbFilename);
 
-    wFilename = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wFilename = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wFilename );
     wFilename.addModifyListener( lsMod );
     FormData fdFilename = new FormData();
@@ -234,9 +234,9 @@ public class ActionMysqlBulkLoadDialog extends ActionDialog implements IActionDi
     wFilename.setLayoutData(fdFilename);
 
     // Whenever something changes, set the tooltip to the expanded version:
-    wFilename.addModifyListener( e -> wFilename.setToolTipText( workflowMeta.environmentSubstitute( wFilename.getText() ) ) );
+    wFilename.addModifyListener( e -> wFilename.setToolTipText( getWorkflowMeta().environmentSubstitute( wFilename.getText() ) ) );
 
-    wbFilename.addListener( SWT.Selection, e-> BaseDialog.presentFileDialog( shell, wFilename, workflowMeta,
+    wbFilename.addListener( SWT.Selection, e-> BaseDialog.presentFileDialog( shell, wFilename, getWorkflowMeta(),
       new String[] { "*.txt", "*.csv", "*"  }, FILETYPES, true )
     );
 
@@ -304,7 +304,7 @@ public class ActionMysqlBulkLoadDialog extends ActionDialog implements IActionDi
     fdlSeparator.top = new FormAttachment( wProrityValue, margin );
     wlSeparator.setLayoutData(fdlSeparator);
 
-    wSeparator = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wSeparator = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wSeparator );
     wSeparator.addModifyListener( lsMod );
     FormData fdSeparator = new FormData();
@@ -324,7 +324,7 @@ public class ActionMysqlBulkLoadDialog extends ActionDialog implements IActionDi
     fdlEnclosed.top = new FormAttachment( wSeparator, margin );
     wlEnclosed.setLayoutData(fdlEnclosed);
 
-    wEnclosed = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wEnclosed = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wEnclosed );
     wEnclosed.addModifyListener( lsMod );
     FormData fdEnclosed = new FormData();
@@ -344,7 +344,7 @@ public class ActionMysqlBulkLoadDialog extends ActionDialog implements IActionDi
     fdlEscaped.top = new FormAttachment( wEnclosed, margin );
     wlEscaped.setLayoutData(fdlEscaped);
 
-    wEscaped = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wEscaped = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wEscaped );
     wEscaped.setToolTipText( BaseMessages.getString( PKG, "JobMysqlBulkLoad.Escaped.Tooltip" ) );
     wEscaped.addModifyListener( lsMod );
@@ -365,7 +365,7 @@ public class ActionMysqlBulkLoadDialog extends ActionDialog implements IActionDi
     fdlLinestarted.top = new FormAttachment( wEscaped, margin );
     wlLinestarted.setLayoutData(fdlLinestarted);
 
-    wLinestarted = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wLinestarted = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wLinestarted );
     wLinestarted.addModifyListener( lsMod );
     FormData fdLinestarted = new FormData();
@@ -385,7 +385,7 @@ public class ActionMysqlBulkLoadDialog extends ActionDialog implements IActionDi
     fdlLineterminated.top = new FormAttachment( wLinestarted, margin );
     wlLineterminated.setLayoutData(fdlLineterminated);
 
-    wLineterminated = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wLineterminated = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wLineterminated );
     wLineterminated.addModifyListener( lsMod );
     FormData fdLineterminated = new FormData();
@@ -418,7 +418,7 @@ public class ActionMysqlBulkLoadDialog extends ActionDialog implements IActionDi
       }
     } );
 
-    wListattribut = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wListattribut = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wListattribut );
     wListattribut.setToolTipText( BaseMessages.getString( PKG, "JobMysqlBulkLoad.Listattribut.Tooltip" ) );
     wListattribut.addModifyListener( lsMod );
@@ -463,7 +463,7 @@ public class ActionMysqlBulkLoadDialog extends ActionDialog implements IActionDi
     fdlIgnorelines.top = new FormAttachment( wReplacedata, margin );
     wlIgnorelines.setLayoutData(fdlIgnorelines);
 
-    wIgnorelines = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wIgnorelines = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wIgnorelines );
     wIgnorelines.addModifyListener( lsMod );
     FormData fdIgnorelines = new FormData();
@@ -654,7 +654,7 @@ public class ActionMysqlBulkLoadDialog extends ActionDialog implements IActionDi
       return;
     }
     action.setName( wName.getText() );
-    action.setDatabase( workflowMeta.findDatabase( wConnection.getText() ) );
+    action.setDatabase( getWorkflowMeta().findDatabase( wConnection.getText() ) );
     action.setSchemaname( wSchemaname.getText() );
     action.setTablename( wTablename.getText() );
     action.setFilename( wFilename.getText() );
@@ -677,9 +677,9 @@ public class ActionMysqlBulkLoadDialog extends ActionDialog implements IActionDi
   private void getTableName() {
     String databaseName = wConnection.getText();
     if ( StringUtils.isNotEmpty( databaseName ) ) {
-      DatabaseMeta databaseMeta = workflowMeta.findDatabase( databaseName );
+      DatabaseMeta databaseMeta = getWorkflowMeta().findDatabase( databaseName );
       if ( databaseMeta != null ) {
-        DatabaseExplorerDialog std = new DatabaseExplorerDialog( shell, SWT.NONE, databaseMeta, workflowMeta.getDatabases() );
+        DatabaseExplorerDialog std = new DatabaseExplorerDialog( shell, SWT.NONE, databaseMeta, getWorkflowMeta().getDatabases() );
         std.setSelectedSchemaAndTable( wSchemaname.getText(), wTablename.getText() );
         if ( std.open() ) {
           wTablename.setText( Const.NVL( std.getTableName(), "" ) );
@@ -698,10 +698,10 @@ public class ActionMysqlBulkLoadDialog extends ActionDialog implements IActionDi
    */
   private void getListColumns() {
     if ( !Utils.isEmpty( wTablename.getText() ) ) {
-      DatabaseMeta databaseMeta = workflowMeta.findDatabase( wConnection.getText() );
+      DatabaseMeta databaseMeta = getWorkflowMeta().findDatabase( wConnection.getText() );
       if ( databaseMeta != null ) {
         Database database = new Database( loggingObject, databaseMeta );
-        database.shareVariablesWith( workflowMeta );
+        database.shareVariablesWith( getWorkflowMeta() );
         try {
           database.connect();
           String schemaTable =

--- a/plugins/actions/pgpfiles/src/main/java/org/apache/hop/workflow/actions/pgpdecryptfiles/ActionPGPDecryptFilesDialog.java
+++ b/plugins/actions/pgpfiles/src/main/java/org/apache/hop/workflow/actions/pgpdecryptfiles/ActionPGPDecryptFilesDialog.java
@@ -150,7 +150,7 @@ public class ActionPGPDecryptFilesDialog extends ActionDialog implements IAction
 
   public ActionPGPDecryptFilesDialog( Shell parent, IAction action,
                                       WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionPGPDecryptFiles) action;
 
     if ( this.action.getName() == null ) {
@@ -166,6 +166,8 @@ public class ActionPGPDecryptFilesDialog extends ActionDialog implements IAction
     props.setLook( shell );
     WorkflowDialog.setShellImage( shell, action );
 
+    WorkflowMeta workflowMeta = getWorkflowMeta();
+    
     ModifyListener lsMod = e -> action.setChanged();
     changed = action.hasChanged();
 

--- a/plugins/actions/pgpfiles/src/main/java/org/apache/hop/workflow/actions/pgpencryptfiles/ActionPGPEncryptFilesDialog.java
+++ b/plugins/actions/pgpfiles/src/main/java/org/apache/hop/workflow/actions/pgpencryptfiles/ActionPGPEncryptFilesDialog.java
@@ -152,7 +152,7 @@ public class ActionPGPEncryptFilesDialog extends ActionDialog implements IAction
 
   public ActionPGPEncryptFilesDialog( Shell parent, IAction action,
                                       WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionPGPEncryptFiles) action;
 
     if ( this.action.getName() == null ) {
@@ -168,7 +168,8 @@ public class ActionPGPEncryptFilesDialog extends ActionDialog implements IAction
     shell = new Shell( parent, SWT.DIALOG_TRIM | SWT.MIN | SWT.MAX | SWT.RESIZE );
     props.setLook( shell );
     WorkflowDialog.setShellImage( shell, action );
-
+    WorkflowMeta workflowMeta = getWorkflowMeta();
+    
     ModifyListener lsMod = e -> action.setChanged();
     changed = action.hasChanged();
 

--- a/plugins/actions/pgpfiles/src/main/java/org/apache/hop/workflow/actions/pgpverify/ActionPGPVerifyDialog.java
+++ b/plugins/actions/pgpfiles/src/main/java/org/apache/hop/workflow/actions/pgpverify/ActionPGPVerifyDialog.java
@@ -76,7 +76,7 @@ public class ActionPGPVerifyDialog extends ActionDialog implements IActionDialog
   private boolean changed;
 
   public ActionPGPVerifyDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent,  workflowMeta );
     this.action = (ActionPGPVerify) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "JobPGPVerify.Name.Default" ) );
@@ -90,7 +90,7 @@ public class ActionPGPVerifyDialog extends ActionDialog implements IActionDialog
     shell = new Shell( parent, SWT.DIALOG_TRIM | SWT.MIN | SWT.MAX | SWT.RESIZE );
     props.setLook( shell );
     WorkflowDialog.setShellImage( shell, action );
-
+    WorkflowMeta workflowMeta = getWorkflowMeta();
     ModifyListener lsMod = e -> action.setChanged();
     changed = action.hasChanged();
 

--- a/plugins/actions/ping/src/main/java/org/apache/hop/workflow/actions/ping/ActionPingDialog.java
+++ b/plugins/actions/ping/src/main/java/org/apache/hop/workflow/actions/ping/ActionPingDialog.java
@@ -69,7 +69,7 @@ public class ActionPingDialog extends ActionDialog implements IActionDialog {
   private boolean changed;
 
   public ActionPingDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionPing) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "JobPing.Name.Default" ) );
@@ -125,7 +125,7 @@ public class ActionPingDialog extends ActionDialog implements IActionDialog {
     fdlHostname.right = new FormAttachment( middle, 0 );
     wlHostname.setLayoutData(fdlHostname);
 
-    wHostname = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wHostname = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wHostname );
     wHostname.addModifyListener( lsMod );
     FormData fdHostname = new FormData();
@@ -135,7 +135,7 @@ public class ActionPingDialog extends ActionDialog implements IActionDialog {
     wHostname.setLayoutData(fdHostname);
 
     // Whenever something changes, set the tooltip to the expanded version:
-    wHostname.addModifyListener( e -> wHostname.setToolTipText( workflowMeta.environmentSubstitute( wHostname.getText() ) ) );
+    wHostname.addModifyListener( e -> wHostname.setToolTipText( getWorkflowMeta().environmentSubstitute( wHostname.getText() ) ) );
 
     Label wlPingType = new Label(shell, SWT.RIGHT);
     wlPingType.setText( BaseMessages.getString( PKG, "JobPing.PingType.Label" ) );
@@ -173,7 +173,7 @@ public class ActionPingDialog extends ActionDialog implements IActionDialog {
     fdlTimeOut.top = new FormAttachment( wPingType, margin );
     wlTimeOut.setLayoutData(fdlTimeOut);
 
-    wTimeOut = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wTimeOut = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     wlTimeOut.setToolTipText( BaseMessages.getString( PKG, "JobPing.TimeOut.Tooltip" ) );
     props.setLook( wTimeOut );
     wTimeOut.addModifyListener( lsMod );
@@ -193,7 +193,7 @@ public class ActionPingDialog extends ActionDialog implements IActionDialog {
     fdlNbrPackets.top = new FormAttachment( wTimeOut, margin );
     wlNbrPackets.setLayoutData(fdlNbrPackets);
 
-    wNbrPackets = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wNbrPackets = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wNbrPackets );
     wNbrPackets.addModifyListener( lsMod );
     FormData fdNbrPackets = new FormData();

--- a/plugins/actions/sendnagiospassivecheck/src/main/java/org/apache/hop/workflow/actions/sendnagiospassivecheck/ActionSendNagiosPassiveCheckDialog.java
+++ b/plugins/actions/sendnagiospassivecheck/src/main/java/org/apache/hop/workflow/actions/sendnagiospassivecheck/ActionSendNagiosPassiveCheckDialog.java
@@ -86,7 +86,7 @@ public class ActionSendNagiosPassiveCheckDialog extends ActionDialog implements 
 
   public ActionSendNagiosPassiveCheckDialog( Shell parent, IAction action,
                                              WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionSendNagiosPassiveCheck) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "JobSendNagiosPassiveCheck.Name.Default" ) );
@@ -158,7 +158,7 @@ public class ActionSendNagiosPassiveCheckDialog extends ActionDialog implements 
     wServerSettings.setLayout( ServerSettingsgroupLayout );
 
     // ServerName line
-    wServerName = new LabelTextVar( workflowMeta, wServerSettings,
+    wServerName = new LabelTextVar( getWorkflowMeta(), wServerSettings,
       BaseMessages.getString( PKG, "JobSendNagiosPassiveCheck.Server.Label" ),
       BaseMessages.getString( PKG, "JobSendNagiosPassiveCheck.Server.Tooltip" ) );
     props.setLook( wServerName );
@@ -170,7 +170,7 @@ public class ActionSendNagiosPassiveCheckDialog extends ActionDialog implements 
     wServerName.setLayoutData(fdServerName);
 
     // Server port line
-    wPort = new LabelTextVar( workflowMeta, wServerSettings,
+    wPort = new LabelTextVar( getWorkflowMeta(), wServerSettings,
       BaseMessages.getString( PKG, "JobSendNagiosPassiveCheck.Port.Label" ),
       BaseMessages.getString( PKG, "JobSendNagiosPassiveCheck.Port.Tooltip" ) );
     props.setLook( wPort );
@@ -183,7 +183,7 @@ public class ActionSendNagiosPassiveCheckDialog extends ActionDialog implements 
 
     // Password String line
     wPassword =
-      new LabelTextVar( workflowMeta, wServerSettings, BaseMessages.getString(
+      new LabelTextVar( getWorkflowMeta(), wServerSettings, BaseMessages.getString(
         PKG, "JobSendNagiosPassiveCheck.Password.Label" ), BaseMessages
         .getString( "JobSendNagiosPassiveCheck.Password.Tooltip" ), true );
     props.setLook( wPassword );
@@ -196,7 +196,7 @@ public class ActionSendNagiosPassiveCheckDialog extends ActionDialog implements 
 
     // Server wConnectionTimeOut line
     wConnectionTimeOut =
-      new LabelTextVar( workflowMeta, wServerSettings,
+      new LabelTextVar( getWorkflowMeta(), wServerSettings,
         BaseMessages.getString( PKG, "JobSendNagiosPassiveCheck.ConnectionTimeOut.Label" ),
         BaseMessages.getString( PKG, "JobSendNagiosPassiveCheck.ConnectionTimeOut.Tooltip" ) );
     props.setLook( wConnectionTimeOut );
@@ -208,7 +208,7 @@ public class ActionSendNagiosPassiveCheckDialog extends ActionDialog implements 
     wConnectionTimeOut.setLayoutData(fdwConnectionTimeOut);
 
     // ResponseTimeOut line
-    wResponseTimeOut = new LabelTextVar( workflowMeta, wServerSettings,
+    wResponseTimeOut = new LabelTextVar( getWorkflowMeta(), wServerSettings,
       BaseMessages.getString( PKG, "JobSendNagiosPassiveCheck.ResponseTimeOut.Label" ),
       BaseMessages.getString( PKG, "JobSendNagiosPassiveCheck.ResponseTimeOut.Tooltip" ) );
     props.setLook( wResponseTimeOut );
@@ -251,7 +251,7 @@ public class ActionSendNagiosPassiveCheckDialog extends ActionDialog implements 
     wSenderSettings.setLayout( SenderSettingsgroupLayout );
 
     // SenderServerName line
-    wSenderServerName = new LabelTextVar( workflowMeta, wSenderSettings,
+    wSenderServerName = new LabelTextVar( getWorkflowMeta(), wSenderSettings,
       BaseMessages.getString( PKG, "JobSendNagiosPassiveCheck.SenderServerName.Label" ),
       BaseMessages.getString( PKG, "JobSendNagiosPassiveCheck.SenderServerName.Tooltip" ) );
     props.setLook( wSenderServerName );
@@ -263,7 +263,7 @@ public class ActionSendNagiosPassiveCheckDialog extends ActionDialog implements 
     wSenderServerName.setLayoutData(fdSenderServerName);
 
     // SenderServiceName line
-    wSenderServiceName = new LabelTextVar( workflowMeta, wSenderSettings,
+    wSenderServiceName = new LabelTextVar( getWorkflowMeta(), wSenderSettings,
       BaseMessages.getString( PKG, "JobSendNagiosPassiveCheck.SenderServiceName.Label" ),
       BaseMessages.getString( PKG, "JobSendNagiosPassiveCheck.SenderServiceName.Tooltip" ) );
     props.setLook( wSenderServiceName );
@@ -353,7 +353,7 @@ public class ActionSendNagiosPassiveCheckDialog extends ActionDialog implements 
     wlMessage.setLayoutData(fdlMessage);
 
     wMessage =
-      new StyledTextComp( workflowMeta, wMessageGroup, SWT.MULTI
+      new StyledTextComp( getWorkflowMeta(), wMessageGroup, SWT.MULTI
         | SWT.LEFT | SWT.BORDER | SWT.H_SCROLL | SWT.V_SCROLL, "" );
     props.setLook( wMessage );
     wMessage.addModifyListener( lsMod );
@@ -447,11 +447,11 @@ public class ActionSendNagiosPassiveCheckDialog extends ActionDialog implements 
   private void test() {
     boolean testOK = false;
     String errMsg = null;
-    String hostname = workflowMeta.environmentSubstitute( wServerName.getText() );
+    String hostname = getWorkflowMeta().environmentSubstitute( wServerName.getText() );
     int nrPort =
       Const.toInt(
-        workflowMeta.environmentSubstitute( "" + wPort.getText() ), ActionSendNagiosPassiveCheck.DEFAULT_PORT );
-    int realConnectionTimeOut = Const.toInt( workflowMeta.environmentSubstitute( wConnectionTimeOut.getText() ), -1 );
+    		  getWorkflowMeta().environmentSubstitute( "" + wPort.getText() ), ActionSendNagiosPassiveCheck.DEFAULT_PORT );
+    int realConnectionTimeOut = Const.toInt( getWorkflowMeta().environmentSubstitute( wConnectionTimeOut.getText() ), -1 );
 
     try {
       SocketUtil.connectToHost( hostname, nrPort, realConnectionTimeOut );

--- a/plugins/actions/setvariables/src/main/java/org/apache/hop/workflow/actions/setvariables/ActionSetVariablesDialog.java
+++ b/plugins/actions/setvariables/src/main/java/org/apache/hop/workflow/actions/setvariables/ActionSetVariablesDialog.java
@@ -68,7 +68,7 @@ public class ActionSetVariablesDialog extends ActionDialog implements IActionDia
   private boolean changed;
 
   public ActionSetVariablesDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionSetVariables) action;
 
     if ( this.action.getName() == null ) {
@@ -133,7 +133,7 @@ public class ActionSetVariablesDialog extends ActionDialog implements IActionDia
     fdlFilename.right = new FormAttachment( middle, -margin );
     fdlFilename.top = new FormAttachment( 0, margin );
     wlFilename.setLayoutData(fdlFilename);
-    wFilename = new TextVar( workflowMeta, gFilename, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wFilename = new TextVar( getWorkflowMeta(), gFilename, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wFilename );
     wFilename.addModifyListener( lsMod );
     FormData fdFilename = new FormData();
@@ -240,7 +240,7 @@ public class ActionSetVariablesDialog extends ActionDialog implements IActionDia
 
     wFields =
       new TableView(
-        workflowMeta, shell, SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI, colinf, FieldsRows, lsMod, props );
+    		  getWorkflowMeta(), shell, SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI, colinf, FieldsRows, lsMod, props );
 
     FormData fdFields = new FormData();
     fdFields.left = new FormAttachment( 0, 0 );

--- a/plugins/actions/shell/src/main/java/org/apache/hop/workflow/actions/shell/ActionShellDialog.java
+++ b/plugins/actions/shell/src/main/java/org/apache/hop/workflow/actions/shell/ActionShellDialog.java
@@ -123,7 +123,7 @@ public class ActionShellDialog extends ActionDialog implements IActionDialog {
   private Text wScript;
 
   public ActionShellDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionShell) action;
   }
 
@@ -232,7 +232,7 @@ public class ActionShellDialog extends ActionDialog implements IActionDialog {
     fdbFilename.right = new FormAttachment( 100, 0 );
     wbFilename.setLayoutData(fdbFilename);
 
-    wFilename = new TextVar( workflowMeta, wGeneralComp, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wFilename = new TextVar( getWorkflowMeta(), wGeneralComp, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wFilename );
     wFilename.addModifyListener( lsMod );
     FormData fdFilename = new FormData();
@@ -253,7 +253,7 @@ public class ActionShellDialog extends ActionDialog implements IActionDialog {
     fdlWorkDirectory.right = new FormAttachment( middle, 0 );
     wlWorkDirectory.setLayoutData(fdlWorkDirectory);
 
-    wWorkDirectory = new TextVar( workflowMeta, wGeneralComp, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wWorkDirectory = new TextVar( getWorkflowMeta(), wGeneralComp, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wWorkDirectory );
     wWorkDirectory.addModifyListener( lsMod );
     FormData fdWorkDirectory = new FormData();
@@ -329,7 +329,7 @@ public class ActionShellDialog extends ActionDialog implements IActionDialog {
     fdlLogfile.top = new FormAttachment( wAppendLogfile, margin );
     fdlLogfile.right = new FormAttachment( middle, 0 );
     wlLogfile.setLayoutData(fdlLogfile);
-    wLogfile = new TextVar( workflowMeta, wLogging, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wLogfile = new TextVar( getWorkflowMeta(), wLogging, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     wLogfile.setText( "" );
     props.setLook( wLogfile );
     FormData fdLogfile = new FormData();
@@ -347,7 +347,7 @@ public class ActionShellDialog extends ActionDialog implements IActionDialog {
     fdlLogext.top = new FormAttachment( wLogfile, margin );
     fdlLogext.right = new FormAttachment( middle, 0 );
     wlLogext.setLayoutData(fdlLogext);
-    wLogext = new TextVar( workflowMeta, wLogging, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wLogext = new TextVar( getWorkflowMeta(), wLogging, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     wLogext.setText( "" );
     props.setLook( wLogext );
     FormData fdLogext = new FormData();
@@ -499,7 +499,7 @@ public class ActionShellDialog extends ActionDialog implements IActionDialog {
 
     wFields =
       new TableView(
-        workflowMeta, wGeneralComp, SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI, colinf, FieldsRows, lsMod, props );
+    		  getWorkflowMeta(), wGeneralComp, SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI, colinf, FieldsRows, lsMod, props );
 
     FormData fdFields = new FormData();
     fdFields.left = new FormAttachment( 0, 0 );
@@ -597,7 +597,7 @@ public class ActionShellDialog extends ActionDialog implements IActionDialog {
     wName.addSelectionListener(lsDef);
     wFilename.addSelectionListener(lsDef);
 
-    wbFilename.addListener( SWT.Selection, e-> BaseDialog.presentFileDialog( shell, wFilename, workflowMeta,
+    wbFilename.addListener( SWT.Selection, e-> BaseDialog.presentFileDialog( shell, wFilename, getWorkflowMeta(),
       new String[] { "*.sh;*.bat;*.BAT", "*;*.*" }, FILEFORMATS, true ));
 
 

--- a/plugins/actions/shell/src/test/java/org/apache/hop/workflow/actions/shell/WorkflowActionShellTest.java
+++ b/plugins/actions/shell/src/test/java/org/apache/hop/workflow/actions/shell/WorkflowActionShellTest.java
@@ -31,7 +31,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.verify;
 
-public class WorkflowEntryShellTest {
+public class WorkflowActionShellTest {
 
   @Mock
   private ActionShell jobEntryShellMock;

--- a/plugins/actions/simpleeval/src/main/java/org/apache/hop/workflow/actions/simpleeval/ActionSimpleEvalDialog.java
+++ b/plugins/actions/simpleeval/src/main/java/org/apache/hop/workflow/actions/simpleeval/ActionSimpleEvalDialog.java
@@ -93,7 +93,7 @@ public class ActionSimpleEvalDialog extends ActionDialog implements IActionDialo
   private TextVar wFieldName;
 
   public ActionSimpleEvalDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionSimpleEval) action;
   }
 
@@ -203,7 +203,7 @@ public class ActionSimpleEvalDialog extends ActionDialog implements IActionDialo
     wlFieldName.setLayoutData(fdlFieldName);
 
     wFieldName =
-      new TextVar( workflowMeta, wSource, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
+      new TextVar( getWorkflowMeta(), wSource, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
         PKG, "JobSimpleEval.FieldName.Tooltip" ) );
     props.setLook( wFieldName );
     wFieldName.addModifyListener( lsMod );
@@ -224,7 +224,7 @@ public class ActionSimpleEvalDialog extends ActionDialog implements IActionDialo
     wlVariableName.setLayoutData(fdlVariableName);
 
     wVariableName =
-      new TextVar( workflowMeta, wSource, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
+      new TextVar( getWorkflowMeta(), wSource, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
         PKG, "JobSimpleEval.Variable.Tooltip" ) );
     props.setLook( wVariableName );
     wVariableName.addModifyListener( lsMod );
@@ -270,7 +270,7 @@ public class ActionSimpleEvalDialog extends ActionDialog implements IActionDialo
     fdlMask.top = new FormAttachment( wFieldType, margin );
     wlMask.setLayoutData( fdlMask );
 
-    wMask = new ComboVar( workflowMeta, wSource, SWT.BORDER | SWT.READ_ONLY );
+    wMask = new ComboVar( getWorkflowMeta(), wSource, SWT.BORDER | SWT.READ_ONLY );
     wMask.setItems( Const.getDateFormats() );
     wMask.setEditable( true );
     props.setLook( wMask );
@@ -424,7 +424,7 @@ public class ActionSimpleEvalDialog extends ActionDialog implements IActionDialo
     wlCompareValue.setLayoutData(fdlCompareValue);
 
     wCompareValue =
-      new TextVar( workflowMeta, wSuccessOn, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
+      new TextVar( getWorkflowMeta(), wSuccessOn, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
         PKG, "JobSimpleEval.CompareValue.Tooltip" ) );
     props.setLook( wCompareValue );
     wCompareValue.addModifyListener( lsMod );
@@ -445,7 +445,7 @@ public class ActionSimpleEvalDialog extends ActionDialog implements IActionDialo
     wlMinValue.setLayoutData(fdlMinValue);
 
     wMinValue =
-      new TextVar( workflowMeta, wSuccessOn, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
+      new TextVar( getWorkflowMeta(), wSuccessOn, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
         PKG, "JobSimpleEval.MinValue.Tooltip" ) );
     props.setLook( wMinValue );
     wMinValue.addModifyListener( lsMod );
@@ -466,7 +466,7 @@ public class ActionSimpleEvalDialog extends ActionDialog implements IActionDialo
     wlMaxValue.setLayoutData(fdlMaxValue);
 
     wMaxValue =
-      new TextVar( workflowMeta, wSuccessOn, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
+      new TextVar( getWorkflowMeta(), wSuccessOn, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
         PKG, "JobSimpleEval.MaxValue.Tooltip" ) );
     props.setLook( wMaxValue );
     wMaxValue.addModifyListener( lsMod );

--- a/plugins/actions/snmptrap/src/main/java/org/apache/hop/workflow/actions/snmptrap/ActionSNMPTrapDialog.java
+++ b/plugins/actions/snmptrap/src/main/java/org/apache/hop/workflow/actions/snmptrap/ActionSNMPTrapDialog.java
@@ -92,7 +92,7 @@ public class ActionSNMPTrapDialog extends ActionDialog implements IActionDialog 
   private CCombo wTargetType;
 
   public ActionSNMPTrapDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionSNMPTrap) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "JobSNMPTrap.Name.Default" ) );
@@ -165,7 +165,7 @@ public class ActionSNMPTrapDialog extends ActionDialog implements IActionDialog 
     // ServerName line
     wServerName =
       new LabelTextVar(
-        workflowMeta, wServerSettings, BaseMessages.getString( PKG, "JobSNMPTrap.Server.Label" ), BaseMessages
+    		  getWorkflowMeta(), wServerSettings, BaseMessages.getString( PKG, "JobSNMPTrap.Server.Label" ), BaseMessages
         .getString( PKG, "JobSNMPTrap.Server.Tooltip" ) );
     props.setLook( wServerName );
     wServerName.addModifyListener( lsMod );
@@ -178,7 +178,7 @@ public class ActionSNMPTrapDialog extends ActionDialog implements IActionDialog 
     // Server port line
     wPort =
       new LabelTextVar(
-        workflowMeta, wServerSettings, BaseMessages.getString( PKG, "JobSNMPTrap.Port.Label" ), BaseMessages
+    		  getWorkflowMeta(), wServerSettings, BaseMessages.getString( PKG, "JobSNMPTrap.Port.Label" ), BaseMessages
         .getString( PKG, "JobSNMPTrap.Port.Tooltip" ) );
     props.setLook( wPort );
     wPort.addModifyListener( lsMod );
@@ -191,7 +191,7 @@ public class ActionSNMPTrapDialog extends ActionDialog implements IActionDialog 
     // Server OID line
     wOID =
       new LabelTextVar(
-        workflowMeta, wServerSettings, BaseMessages.getString( PKG, "JobSNMPTrap.OID.Label" ), BaseMessages
+    		  getWorkflowMeta(), wServerSettings, BaseMessages.getString( PKG, "JobSNMPTrap.OID.Label" ), BaseMessages
         .getString( PKG, "JobSNMPTrap.OID.Tooltip" ) );
     props.setLook( wOID );
     wOID.addModifyListener( lsMod );
@@ -259,7 +259,7 @@ public class ActionSNMPTrapDialog extends ActionDialog implements IActionDialog 
     // Community String line
     wComString =
       new LabelTextVar(
-        workflowMeta, wAdvancedSettings, BaseMessages.getString( PKG, "JobSNMPTrap.ComString.Label" ), BaseMessages
+    		  getWorkflowMeta(), wAdvancedSettings, BaseMessages.getString( PKG, "JobSNMPTrap.ComString.Label" ), BaseMessages
         .getString( PKG, "JobSNMPTrap.ComString.Tooltip" ) );
     props.setLook( wComString );
     wComString.addModifyListener( lsMod );
@@ -272,7 +272,7 @@ public class ActionSNMPTrapDialog extends ActionDialog implements IActionDialog 
     // User line
     wUser =
       new LabelTextVar(
-        workflowMeta, wAdvancedSettings, BaseMessages.getString( PKG, "JobSNMPTrap.User.Label" ), BaseMessages
+    		  getWorkflowMeta(), wAdvancedSettings, BaseMessages.getString( PKG, "JobSNMPTrap.User.Label" ), BaseMessages
         .getString( PKG, "JobSNMPTrap.User.Tooltip" ) );
     props.setLook( wUser );
     wUser.addModifyListener( lsMod );
@@ -285,7 +285,7 @@ public class ActionSNMPTrapDialog extends ActionDialog implements IActionDialog 
     // Passphrase String line
     wPassphrase =
       new LabelTextVar(
-        workflowMeta, wAdvancedSettings, BaseMessages.getString( PKG, "JobSNMPTrap.Passphrase.Label" ),
+    		  getWorkflowMeta(), wAdvancedSettings, BaseMessages.getString( PKG, "JobSNMPTrap.Passphrase.Label" ),
         BaseMessages.getString( PKG, "JobSNMPTrap.Passphrase.Tooltip" ), true );
     props.setLook( wPassphrase );
     wPassphrase.addModifyListener( lsMod );
@@ -298,7 +298,7 @@ public class ActionSNMPTrapDialog extends ActionDialog implements IActionDialog 
     // EngineID String line
     wEngineID =
       new LabelTextVar(
-        workflowMeta, wAdvancedSettings, BaseMessages.getString( PKG, "JobSNMPTrap.EngineID.Label" ), BaseMessages
+    		  getWorkflowMeta(), wAdvancedSettings, BaseMessages.getString( PKG, "JobSNMPTrap.EngineID.Label" ), BaseMessages
         .getString( PKG, "JobSNMPTrap.EngineID.Tooltip" ) );
     props.setLook( wEngineID );
     wEngineID.addModifyListener( lsMod );
@@ -311,7 +311,7 @@ public class ActionSNMPTrapDialog extends ActionDialog implements IActionDialog 
     // Retry line
     wRetry =
       new LabelTextVar(
-        workflowMeta, wAdvancedSettings, BaseMessages.getString( PKG, "JobSNMPTrap.Retry.Label" ), BaseMessages
+    		  getWorkflowMeta(), wAdvancedSettings, BaseMessages.getString( PKG, "JobSNMPTrap.Retry.Label" ), BaseMessages
         .getString( PKG, "JobSNMPTrap.Retry.Tooltip" ) );
     props.setLook( wRetry );
     wRetry.addModifyListener( lsMod );
@@ -324,7 +324,7 @@ public class ActionSNMPTrapDialog extends ActionDialog implements IActionDialog 
     // Timeout line
     wTimeout =
       new LabelTextVar(
-        workflowMeta, wAdvancedSettings, BaseMessages.getString( PKG, "JobSNMPTrap.Timeout.Label" ), BaseMessages
+    		  getWorkflowMeta(), wAdvancedSettings, BaseMessages.getString( PKG, "JobSNMPTrap.Timeout.Label" ), BaseMessages
         .getString( PKG, "JobSNMPTrap.Timeout.Tooltip" ) );
     props.setLook( wTimeout );
     wTimeout.addModifyListener( lsMod );
@@ -465,9 +465,9 @@ public class ActionSNMPTrapDialog extends ActionDialog implements IActionDialog 
   private void test() {
     boolean testOK = false;
     String errMsg = null;
-    String hostname = workflowMeta.environmentSubstitute( wServerName.getText() );
+    String hostname = getWorkflowMeta().environmentSubstitute( wServerName.getText() );
     int nrPort =
-      Const.toInt( workflowMeta.environmentSubstitute( "" + wPort.getText() ), ActionSNMPTrap.DEFAULT_PORT );
+      Const.toInt( getWorkflowMeta().environmentSubstitute( "" + wPort.getText() ), ActionSNMPTrap.DEFAULT_PORT );
 
     try {
       UdpAddress udpAddress = new UdpAddress( InetAddress.getByName( hostname ), nrPort );

--- a/plugins/actions/sql/src/main/java/org/apache/hop/workflow/actions/sql/ActionSqlDialog.java
+++ b/plugins/actions/sql/src/main/java/org/apache/hop/workflow/actions/sql/ActionSqlDialog.java
@@ -87,7 +87,7 @@ public class ActionSqlDialog extends ActionDialog implements IActionDialog {
   private TextVar wFilename;
 
   public ActionSqlDialog(Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionSql) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "JobSQL.Name.Default" ) );
@@ -185,7 +185,7 @@ public class ActionSqlDialog extends ActionDialog implements IActionDialog {
     fdbFilename.top = new FormAttachment( wSqlFromFile, margin );
     wbFilename.setLayoutData(fdbFilename);
 
-    wFilename = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wFilename = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wFilename );
     wFilename.setToolTipText( BaseMessages.getString( PKG, "JobSQL.Filename.Tooltip" ) );
     wFilename.addModifyListener( lsMod );
@@ -196,9 +196,9 @@ public class ActionSqlDialog extends ActionDialog implements IActionDialog {
     wFilename.setLayoutData(fdFilename);
 
     // Whenever something changes, set the tooltip to the expanded version:
-    wFilename.addModifyListener( e -> wFilename.setToolTipText( workflowMeta.environmentSubstitute( wFilename.getText() ) ) );
+    wFilename.addModifyListener( e -> wFilename.setToolTipText( getWorkflowMeta().environmentSubstitute( wFilename.getText() ) ) );
 
-    wbFilename.addListener( SWT.Selection, e-> BaseDialog.presentFileDialog( shell, wFilename, workflowMeta,
+    wbFilename.addListener( SWT.Selection, e-> BaseDialog.presentFileDialog( shell, wFilename, getWorkflowMeta(),
       new String[] { "*.sql", "*.txt", "*" }, FILETYPES, true )
     );
 
@@ -428,7 +428,7 @@ public class ActionSqlDialog extends ActionDialog implements IActionDialog {
     action.setSqlFromFile( wSqlFromFile.getSelection() );
     action.setSqlFilename( wFilename.getText() );
     action.setSendOneStatement( wSendOneStatement.getSelection() );
-    action.setDatabase( workflowMeta.findDatabase( wConnection.getText() ) );
+    action.setDatabase( getWorkflowMeta().findDatabase( wConnection.getText() ) );
     dispose();
   }
 }

--- a/plugins/actions/success/src/main/java/org/apache/hop/workflow/actions/success/ActionSuccessDialog.java
+++ b/plugins/actions/success/src/main/java/org/apache/hop/workflow/actions/success/ActionSuccessDialog.java
@@ -57,7 +57,7 @@ public class ActionSuccessDialog extends ActionDialog implements IActionDialog {
   private boolean changed;
 
   public ActionSuccessDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionSuccess) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "ActionSuccessDialog.Name.Default" ) );

--- a/plugins/actions/syslog/src/main/java/org/apache/hop/workflow/actions/syslog/ActionSyslogDialog.java
+++ b/plugins/actions/syslog/src/main/java/org/apache/hop/workflow/actions/syslog/ActionSyslogDialog.java
@@ -86,7 +86,7 @@ public class ActionSyslogDialog extends ActionDialog implements IActionDialog {
   private Button wAddHostName;
 
   public ActionSyslogDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionSyslog) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "ActionSyslog.Name.Default" ) );
@@ -159,7 +159,7 @@ public class ActionSyslogDialog extends ActionDialog implements IActionDialog {
     // Server port line
     wServerName =
       new LabelTextVar(
-        workflowMeta, wServerSettings, BaseMessages.getString( PKG, "ActionSyslog.Server.Label" ), BaseMessages
+    		  getWorkflowMeta(), wServerSettings, BaseMessages.getString( PKG, "ActionSyslog.Server.Label" ), BaseMessages
         .getString( PKG, "ActionSyslog.Server.Tooltip" ) );
     props.setLook( wServerName );
     wServerName.addModifyListener( lsMod );
@@ -172,7 +172,7 @@ public class ActionSyslogDialog extends ActionDialog implements IActionDialog {
     // Server port line
     wPort =
       new LabelTextVar(
-        workflowMeta, wServerSettings, BaseMessages.getString( PKG, "ActionSyslog.Port.Label" ), BaseMessages
+    		  getWorkflowMeta(), wServerSettings, BaseMessages.getString( PKG, "ActionSyslog.Port.Label" ), BaseMessages
         .getString( PKG, "ActionSyslog.Port.Tooltip" ) );
     props.setLook( wPort );
     wPort.addModifyListener( lsMod );
@@ -338,7 +338,7 @@ public class ActionSyslogDialog extends ActionDialog implements IActionDialog {
     fdlDatePattern.right = new FormAttachment( middle, -margin );
     fdlDatePattern.top = new FormAttachment( wAddTimestamp, margin );
     wlDatePattern.setLayoutData(fdlDatePattern);
-    wDatePattern = new ComboVar( workflowMeta, wMessageGroup, SWT.SINGLE | SWT.READ_ONLY | SWT.BORDER );
+    wDatePattern = new ComboVar( getWorkflowMeta(), wMessageGroup, SWT.SINGLE | SWT.READ_ONLY | SWT.BORDER );
     wDatePattern.setItems( Const.getDateFormats() );
     props.setLook( wDatePattern );
     FormData fdDatePattern = new FormData();
@@ -460,8 +460,8 @@ public class ActionSyslogDialog extends ActionDialog implements IActionDialog {
   private void test() {
     boolean testOK = false;
     String errMsg = null;
-    String hostname = workflowMeta.environmentSubstitute( wServerName.getText() );
-    int nrPort = Const.toInt( workflowMeta.environmentSubstitute( "" + wPort.getText() ), SyslogDefs.DEFAULT_PORT );
+    String hostname = getWorkflowMeta().environmentSubstitute( wServerName.getText() );
+    int nrPort = Const.toInt( getWorkflowMeta().environmentSubstitute( "" + wPort.getText() ), SyslogDefs.DEFAULT_PORT );
 
     try {
       UdpAddress udpAddress = new UdpAddress( InetAddress.getByName( hostname ), nrPort );

--- a/plugins/actions/tableexists/src/main/java/org/apache/hop/workflow/actions/tableexists/ActionTableExistsDialog.java
+++ b/plugins/actions/tableexists/src/main/java/org/apache/hop/workflow/actions/tableexists/ActionTableExistsDialog.java
@@ -72,7 +72,7 @@ public class ActionTableExistsDialog extends ActionDialog implements IActionDial
   private boolean changed;
 
   public ActionTableExistsDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionTableExists) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "JobTableExists.Name.Default" ) );
@@ -144,7 +144,7 @@ public class ActionTableExistsDialog extends ActionDialog implements IActionDial
       }
     } );
 
-    wSchemaname = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wSchemaname = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wSchemaname );
     wSchemaname.addModifyListener( lsMod );
     FormData fdSchemaname = new FormData();
@@ -176,7 +176,7 @@ public class ActionTableExistsDialog extends ActionDialog implements IActionDial
       }
     } );
 
-    wTablename = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wTablename = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wTablename );
     wTablename.addModifyListener( lsMod );
     FormData fdTablename = new FormData();
@@ -274,7 +274,7 @@ public class ActionTableExistsDialog extends ActionDialog implements IActionDial
       return;
     }
     action.setName( wName.getText() );
-    action.setDatabase( workflowMeta.findDatabase( wConnection.getText() ) );
+    action.setDatabase( getWorkflowMeta().findDatabase( wConnection.getText() ) );
     action.setTablename( wTablename.getText() );
     action.setSchemaname( wSchemaname.getText() );
 
@@ -285,10 +285,10 @@ public class ActionTableExistsDialog extends ActionDialog implements IActionDial
     if ( wSchemaname.isDisposed() ) {
       return;
     }
-    DatabaseMeta databaseMeta = workflowMeta.findDatabase( wConnection.getText() );
+    DatabaseMeta databaseMeta = getWorkflowMeta().findDatabase( wConnection.getText() );
     if ( databaseMeta != null ) {
       Database database = new Database( loggingObject, databaseMeta );
-      database.shareVariablesWith( workflowMeta );
+      database.shareVariablesWith( getWorkflowMeta() );
       try {
         database.connect();
         String[] schemas = database.getSchemas();
@@ -324,9 +324,9 @@ public class ActionTableExistsDialog extends ActionDialog implements IActionDial
   private void getTableName() {
     String databaseName = wConnection.getText();
     if ( StringUtils.isNotEmpty( databaseName ) ) {
-      DatabaseMeta databaseMeta = workflowMeta.findDatabase( databaseName );
+      DatabaseMeta databaseMeta = getWorkflowMeta().findDatabase( databaseName );
       if ( databaseMeta != null ) {
-        DatabaseExplorerDialog std = new DatabaseExplorerDialog( shell, SWT.NONE, databaseMeta, workflowMeta.getDatabases() );
+        DatabaseExplorerDialog std = new DatabaseExplorerDialog( shell, SWT.NONE, databaseMeta, getWorkflowMeta().getDatabases() );
         std.setSelectedSchemaAndTable( wSchemaname.getText(), wTablename.getText() );
         if ( std.open() ) {
           wSchemaname.setText( Const.NVL( std.getSchemaName(), "" ) );

--- a/plugins/actions/telnet/src/main/java/org/apache/hop/workflow/actions/telnet/ActionTelnetDialog.java
+++ b/plugins/actions/telnet/src/main/java/org/apache/hop/workflow/actions/telnet/ActionTelnetDialog.java
@@ -64,7 +64,7 @@ public class ActionTelnetDialog extends ActionDialog implements IActionDialog {
   private boolean changed;
 
   public ActionTelnetDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionTelnet) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "JobTelnet.Name.Default" ) );
@@ -120,7 +120,7 @@ public class ActionTelnetDialog extends ActionDialog implements IActionDialog {
     fdlHostname.right = new FormAttachment( middle, -margin );
     wlHostname.setLayoutData(fdlHostname);
 
-    wHostname = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wHostname = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wHostname );
     wHostname.addModifyListener( lsMod );
     FormData fdHostname = new FormData();
@@ -130,7 +130,7 @@ public class ActionTelnetDialog extends ActionDialog implements IActionDialog {
     wHostname.setLayoutData(fdHostname);
 
     // Whenever something changes, set the tooltip to the expanded version:
-    wHostname.addModifyListener( e -> wHostname.setToolTipText( workflowMeta.environmentSubstitute( wHostname.getText() ) ) );
+    wHostname.addModifyListener( e -> wHostname.setToolTipText( getWorkflowMeta().environmentSubstitute( wHostname.getText() ) ) );
 
     Label wlPort = new Label(shell, SWT.RIGHT);
     wlPort.setText( BaseMessages.getString( PKG, "JobTelnet.Port.Label" ) );
@@ -141,7 +141,7 @@ public class ActionTelnetDialog extends ActionDialog implements IActionDialog {
     fdlPort.top = new FormAttachment( wHostname, margin );
     wlPort.setLayoutData(fdlPort);
 
-    wPort = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wPort = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wPort );
     wPort.addModifyListener( lsMod );
     FormData fdPort = new FormData();
@@ -159,7 +159,7 @@ public class ActionTelnetDialog extends ActionDialog implements IActionDialog {
     fdlTimeOut.top = new FormAttachment( wPort, margin );
     wlTimeOut.setLayoutData(fdlTimeOut);
 
-    wTimeOut = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wTimeOut = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wTimeOut );
     wTimeOut.addModifyListener( lsMod );
     FormData fdTimeOut = new FormData();

--- a/plugins/actions/truncatetables/src/main/java/org/apache/hop/workflow/actions/truncatetables/ActionTruncateTablesDialog.java
+++ b/plugins/actions/truncatetables/src/main/java/org/apache/hop/workflow/actions/truncatetables/ActionTruncateTablesDialog.java
@@ -59,6 +59,8 @@ import java.util.Arrays;
 public class ActionTruncateTablesDialog extends ActionDialog implements IActionDialog {
   private static final Class<?> PKG = ActionTruncateTables.class; // for i18n purposes, needed by Translator!!
 
+  private Shell shell;
+  
   private Button wbTable;
 
   private Text wName;
@@ -76,7 +78,7 @@ public class ActionTruncateTablesDialog extends ActionDialog implements IActionD
   private Button wPrevious;
 
   public ActionTruncateTablesDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionTruncateTables) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "ActionTruncateTables.Name.Default" ) );
@@ -204,7 +206,7 @@ public class ActionTruncateTablesDialog extends ActionDialog implements IActionD
 
     wFields =
       new TableView(
-        workflowMeta, shell, SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI, colinf, FieldsRows, lsMod, props );
+    		  getWorkflowMeta(), shell, SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI, colinf, FieldsRows, lsMod, props );
 
     FormData fdFields = new FormData();
     fdFields.left = new FormAttachment( 0, 0 );
@@ -335,7 +337,7 @@ public class ActionTruncateTablesDialog extends ActionDialog implements IActionD
       return;
     }
     action.setName( wName.getText() );
-    action.setDatabase( workflowMeta.findDatabase( wConnection.getText() ) );
+    action.setDatabase( getWorkflowMeta().findDatabase( wConnection.getText() ) );
     action.setArgFromPrevious(wPrevious.getSelection());
 
     int nritems = wFields.nrNonEmpty();
@@ -366,7 +368,7 @@ public class ActionTruncateTablesDialog extends ActionDialog implements IActionD
   }
 
   private void getTableName() {
-    DatabaseMeta databaseMeta = workflowMeta.findDatabase( wConnection.getText() );
+    DatabaseMeta databaseMeta = getWorkflowMeta().findDatabase( wConnection.getText() );
     if ( databaseMeta != null ) {
       Database database = new Database( loggingObject, databaseMeta );
       try {

--- a/plugins/actions/unzip/src/main/java/org/apache/hop/workflow/actions/unzip/ActionUnZipDialog.java
+++ b/plugins/actions/unzip/src/main/java/org/apache/hop/workflow/actions/unzip/ActionUnZipDialog.java
@@ -121,7 +121,7 @@ public class ActionUnZipDialog extends ActionDialog implements IActionDialog {
   private boolean changed;
 
   public ActionUnZipDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionUnZip) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "JobUnZip.Name.Default" ) );
@@ -243,7 +243,7 @@ public class ActionUnZipDialog extends ActionDialog implements IActionDialog {
     fdbSourceDirectory.top = new FormAttachment( wArgsPrevious, margin );
     wbSourceDirectory.setLayoutData(fdbSourceDirectory);
 
-    wbSourceDirectory.addListener( SWT.Selection, e-> BaseDialog.presentDirectoryDialog( shell, wZipFilename, workflowMeta ) );
+    wbSourceDirectory.addListener( SWT.Selection, e-> BaseDialog.presentDirectoryDialog( shell, wZipFilename, getWorkflowMeta() ) );
 
 
     // Browse files...
@@ -255,7 +255,7 @@ public class ActionUnZipDialog extends ActionDialog implements IActionDialog {
     fdbZipFilename.top = new FormAttachment( wArgsPrevious, margin );
     wbZipFilename.setLayoutData(fdbZipFilename);
 
-    wZipFilename = new TextVar( workflowMeta, wSource, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wZipFilename = new TextVar( getWorkflowMeta(), wSource, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wZipFilename );
     wZipFilename.addModifyListener( lsMod );
     FormData fdZipFilename = new FormData();
@@ -266,9 +266,9 @@ public class ActionUnZipDialog extends ActionDialog implements IActionDialog {
     wZipFilename.setLayoutData(fdZipFilename);
 
     // Whenever something changes, set the tooltip to the expanded version:
-    wZipFilename.addModifyListener( e -> wZipFilename.setToolTipText( workflowMeta.environmentSubstitute( wZipFilename.getText() ) ) );
+    wZipFilename.addModifyListener( e -> wZipFilename.setToolTipText( getWorkflowMeta().environmentSubstitute( wZipFilename.getText() ) ) );
 
-    wbZipFilename.addListener( SWT.Selection, e-> BaseDialog.presentFileDialog( shell, wZipFilename, workflowMeta,
+    wbZipFilename.addListener( SWT.Selection, e-> BaseDialog.presentFileDialog( shell, wZipFilename, getWorkflowMeta(),
       new String[] { "*.zip;*.ZIP", "*.jar;*.JAR", "*" }, FILETYPES, true )
     );
 
@@ -282,7 +282,7 @@ public class ActionUnZipDialog extends ActionDialog implements IActionDialog {
     fdlWildcardSource.right = new FormAttachment( middle, -margin );
     wlWildcardSource.setLayoutData(fdlWildcardSource);
     wWildcardSource =
-      new TextVar( workflowMeta, wSource, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
+      new TextVar( getWorkflowMeta(), wSource, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
         PKG, "JobUnZip.WildcardSource.Tooltip" ) );
     props.setLook( wWildcardSource );
     wWildcardSource.addModifyListener( lsMod );
@@ -358,7 +358,7 @@ public class ActionUnZipDialog extends ActionDialog implements IActionDialog {
     wbTargetDirectory.setLayoutData(fdbTargetDirectory);
 
     wTargetDirectory =
-      new TextVar( workflowMeta, wUnzippedFiles, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
+      new TextVar( getWorkflowMeta(), wUnzippedFiles, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
         PKG, "JobUnZip.TargetDir.Tooltip" ) );
     props.setLook( wTargetDirectory );
     wTargetDirectory.addModifyListener( lsMod );
@@ -401,7 +401,7 @@ public class ActionUnZipDialog extends ActionDialog implements IActionDialog {
     fdlWildcard.right = new FormAttachment( middle, -margin );
     wlWildcard.setLayoutData(fdlWildcard);
     wWildcard =
-      new TextVar( workflowMeta, wUnzippedFiles, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
+      new TextVar( getWorkflowMeta(), wUnzippedFiles, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
         PKG, "JobUnZip.Wildcard.Tooltip" ) );
     props.setLook( wWildcard );
     wWildcard.addModifyListener( lsMod );
@@ -421,7 +421,7 @@ public class ActionUnZipDialog extends ActionDialog implements IActionDialog {
     fdlWildcardExclude.right = new FormAttachment( middle, -margin );
     wlWildcardExclude.setLayoutData(fdlWildcardExclude);
     wWildcardExclude =
-      new TextVar( workflowMeta, wUnzippedFiles, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
+      new TextVar( getWorkflowMeta(), wUnzippedFiles, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
         PKG, "JobUnZip.WildcardExclude.Tooltip" ) );
     props.setLook( wWildcardExclude );
     wWildcardExclude.addModifyListener( lsMod );
@@ -639,7 +639,7 @@ public class ActionUnZipDialog extends ActionDialog implements IActionDialog {
     fdlMovetoDirectory.right = new FormAttachment( middle, -margin );
     wlMovetoDirectory.setLayoutData(fdlMovetoDirectory);
     wMovetoDirectory =
-      new TextVar( workflowMeta, wUnzippedFiles, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
+      new TextVar( getWorkflowMeta(), wUnzippedFiles, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
         PKG, "JobUnZip.MovetoDirectory.Tooltip" ) );
     props.setLook( wMovetoDirectory );
 
@@ -820,7 +820,7 @@ public class ActionUnZipDialog extends ActionDialog implements IActionDialog {
     wlNrErrorsLessThan.setLayoutData(fdlNrErrorsLessThan);
 
     wNrErrorsLessThan =
-      new TextVar( workflowMeta, wSuccessOn, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
+      new TextVar( getWorkflowMeta(), wSuccessOn, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
         PKG, "JobUnZip.NrBadFormedLessThan.Tooltip" ) );
     props.setLook( wNrErrorsLessThan );
     wNrErrorsLessThan.addModifyListener( lsMod );
@@ -881,8 +881,8 @@ public class ActionUnZipDialog extends ActionDialog implements IActionDialog {
       }
     };
 
-    wbTargetDirectory.addListener( SWT.Selection, e-> BaseDialog.presentDirectoryDialog( shell, wTargetDirectory, workflowMeta ) );
-    wbMovetoDirectory.addListener( SWT.Selection, e-> BaseDialog.presentDirectoryDialog( shell, wMovetoDirectory, workflowMeta ) );
+    wbTargetDirectory.addListener( SWT.Selection, e-> BaseDialog.presentDirectoryDialog( shell, wTargetDirectory, getWorkflowMeta() ) );
+    wbMovetoDirectory.addListener( SWT.Selection, e-> BaseDialog.presentDirectoryDialog( shell, wMovetoDirectory, getWorkflowMeta() ) );
 
 
     wName.addSelectionListener(lsDef);

--- a/plugins/actions/waitforfile/src/main/java/org/apache/hop/workflow/actions/waitforfile/ActionWaitForFileDialog.java
+++ b/plugins/actions/waitforfile/src/main/java/org/apache/hop/workflow/actions/waitforfile/ActionWaitForFileDialog.java
@@ -73,7 +73,7 @@ public class ActionWaitForFileDialog extends ActionDialog implements IActionDial
   private boolean changed;
 
   public ActionWaitForFileDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionWaitForFile) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "JobWaitForFile.Name.Default" ) );
@@ -137,7 +137,7 @@ public class ActionWaitForFileDialog extends ActionDialog implements IActionDial
     fdbFilename.top = new FormAttachment( wName, 0 );
     wbFilename.setLayoutData(fdbFilename);
 
-    wFilename = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wFilename = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wFilename );
     wFilename.addModifyListener( lsMod );
     FormData fdFilename = new FormData();
@@ -147,9 +147,9 @@ public class ActionWaitForFileDialog extends ActionDialog implements IActionDial
     wFilename.setLayoutData(fdFilename);
 
     // Whenever something changes, set the tooltip to the expanded version:
-    wFilename.addModifyListener( e -> wFilename.setToolTipText( workflowMeta.environmentSubstitute( wFilename.getText() ) ) );
+    wFilename.addModifyListener( e -> wFilename.setToolTipText( getWorkflowMeta().environmentSubstitute( wFilename.getText() ) ) );
 
-    wbFilename.addListener( SWT.Selection, e-> BaseDialog.presentFileDialog( shell, wFilename, workflowMeta,
+    wbFilename.addListener( SWT.Selection, e-> BaseDialog.presentFileDialog( shell, wFilename, getWorkflowMeta(),
       new String[] { "*" }, FILETYPES, true )
     );
 
@@ -162,7 +162,7 @@ public class ActionWaitForFileDialog extends ActionDialog implements IActionDial
     fdlMaximumTimeout.top = new FormAttachment( wFilename, margin );
     fdlMaximumTimeout.right = new FormAttachment( middle, -margin );
     wlMaximumTimeout.setLayoutData(fdlMaximumTimeout);
-    wMaximumTimeout = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wMaximumTimeout = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wMaximumTimeout );
     wMaximumTimeout.setToolTipText( BaseMessages.getString( PKG, "JobWaitForFile.MaximumTimeout.Tooltip" ) );
     wMaximumTimeout.addModifyListener( lsMod );
@@ -181,7 +181,7 @@ public class ActionWaitForFileDialog extends ActionDialog implements IActionDial
     fdlCheckCycleTime.top = new FormAttachment( wMaximumTimeout, margin );
     fdlCheckCycleTime.right = new FormAttachment( middle, -margin );
     wlCheckCycleTime.setLayoutData(fdlCheckCycleTime);
-    wCheckCycleTime = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wCheckCycleTime = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wCheckCycleTime );
     wCheckCycleTime.setToolTipText( BaseMessages.getString( PKG, "JobWaitForFile.CheckCycleTime.Tooltip" ) );
     wCheckCycleTime.addModifyListener( lsMod );

--- a/plugins/actions/waitforsql/src/main/java/org/apache/hop/workflow/actions/waitforsql/ActionWaitForSqlDialog.java
+++ b/plugins/actions/waitforsql/src/main/java/org/apache/hop/workflow/actions/waitforsql/ActionWaitForSqlDialog.java
@@ -110,7 +110,7 @@ public class ActionWaitForSqlDialog extends ActionDialog implements IActionDialo
   private Button wClearResultList;
 
   public ActionWaitForSqlDialog(Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionWaitForSql) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "ActionWaitForSQL.Name.Default" ) );
@@ -187,7 +187,7 @@ public class ActionWaitForSqlDialog extends ActionDialog implements IActionDialo
     fdlSchemaname.top = new FormAttachment( wConnection, margin );
     wlSchemaname.setLayoutData(fdlSchemaname);
 
-    wSchemaname = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wSchemaname = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wSchemaname );
     wSchemaname.setToolTipText( BaseMessages.getString( PKG, "ActionWaitForSQL.Schemaname.Tooltip" ) );
     wSchemaname.addModifyListener( lsMod );
@@ -220,7 +220,7 @@ public class ActionWaitForSqlDialog extends ActionDialog implements IActionDialo
       }
     } );
 
-    wTablename = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wTablename = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wTablename );
     wTablename.setToolTipText( BaseMessages.getString( PKG, "ActionWaitForSQL.Tablename.Tooltip" ) );
     wTablename.addModifyListener( lsMod );
@@ -279,7 +279,7 @@ public class ActionWaitForSqlDialog extends ActionDialog implements IActionDialo
     wlRowsCountValue.setLayoutData(fdlRowsCountValue);
 
     wRowsCountValue =
-      new TextVar( workflowMeta, wSuccessGroup, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
+      new TextVar( getWorkflowMeta(), wSuccessGroup, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
         PKG, "ActionWaitForSQL.RowsCountValue.Tooltip" ) );
     props.setLook( wRowsCountValue );
     wRowsCountValue.addModifyListener( lsMod );
@@ -298,7 +298,7 @@ public class ActionWaitForSqlDialog extends ActionDialog implements IActionDialo
     fdlMaximumTimeout.top = new FormAttachment( wRowsCountValue, margin );
     fdlMaximumTimeout.right = new FormAttachment( middle, -2 * margin );
     wlMaximumTimeout.setLayoutData(fdlMaximumTimeout);
-    wMaximumTimeout = new TextVar( workflowMeta, wSuccessGroup, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wMaximumTimeout = new TextVar( getWorkflowMeta(), wSuccessGroup, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wMaximumTimeout );
     wMaximumTimeout.setToolTipText( BaseMessages.getString( PKG, "ActionWaitForSQL.MaximumTimeout.Tooltip" ) );
     wMaximumTimeout.addModifyListener( lsMod );
@@ -317,7 +317,7 @@ public class ActionWaitForSqlDialog extends ActionDialog implements IActionDialo
     fdlCheckCycleTime.top = new FormAttachment( wMaximumTimeout, margin );
     fdlCheckCycleTime.right = new FormAttachment( middle, -2 * margin );
     wlCheckCycleTime.setLayoutData(fdlCheckCycleTime);
-    wCheckCycleTime = new TextVar( workflowMeta, wSuccessGroup, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wCheckCycleTime = new TextVar( getWorkflowMeta(), wSuccessGroup, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wCheckCycleTime );
     wCheckCycleTime.setToolTipText( BaseMessages.getString( PKG, "ActionWaitForSQL.CheckCycleTime.Tooltip" ) );
     wCheckCycleTime.addModifyListener( lsMod );
@@ -588,9 +588,9 @@ public class ActionWaitForSqlDialog extends ActionDialog implements IActionDialo
   }
 
   private void getSql() {
-    DatabaseMeta inf = workflowMeta.findDatabase( wConnection.getText() );
+    DatabaseMeta inf = getWorkflowMeta().findDatabase( wConnection.getText() );
     if ( inf != null ) {
-      DatabaseExplorerDialog std = new DatabaseExplorerDialog( shell, SWT.NONE, inf, workflowMeta.getDatabases() );
+      DatabaseExplorerDialog std = new DatabaseExplorerDialog( shell, SWT.NONE, inf, getWorkflowMeta().getDatabases() );
       if ( std.open() ) {
         String sql =
           "SELECT *"
@@ -742,7 +742,7 @@ public class ActionWaitForSqlDialog extends ActionDialog implements IActionDialo
       return;
     }
     action.setName( wName.getText() );
-    action.setDatabase( workflowMeta.findDatabase( wConnection.getText() ) );
+    action.setDatabase( getWorkflowMeta().findDatabase( wConnection.getText() ) );
 
     action.schemaname = wSchemaname.getText();
     action.tablename = wTablename.getText();
@@ -763,9 +763,9 @@ public class ActionWaitForSqlDialog extends ActionDialog implements IActionDialo
   private void getTableName() {
     String databaseName = wConnection.getText();
     if ( StringUtils.isNotEmpty( databaseName ) ) {
-      DatabaseMeta databaseMeta = workflowMeta.findDatabase( databaseName );
+      DatabaseMeta databaseMeta = getWorkflowMeta().findDatabase( databaseName );
       if ( databaseMeta != null ) {
-        DatabaseExplorerDialog std = new DatabaseExplorerDialog( shell, SWT.NONE, databaseMeta, workflowMeta.getDatabases() );
+        DatabaseExplorerDialog std = new DatabaseExplorerDialog( shell, SWT.NONE, databaseMeta, getWorkflowMeta().getDatabases() );
         std.setSelectedSchemaAndTable( wSchemaname.getText(), wTablename.getText() );
         if ( std.open() ) {
           wTablename.setText( Const.NVL( std.getTableName(), "" ) );

--- a/plugins/actions/webserviceavailable/src/main/java/org/apache/hop/workflow/actions/webserviceavailable/ActionWebServiceAvailableDialog.java
+++ b/plugins/actions/webserviceavailable/src/main/java/org/apache/hop/workflow/actions/webserviceavailable/ActionWebServiceAvailableDialog.java
@@ -65,7 +65,7 @@ public class ActionWebServiceAvailableDialog extends ActionDialog implements IAc
 
   public ActionWebServiceAvailableDialog( Shell parent, IAction action,
                                           WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionWebServiceAvailable) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "ActionWebServiceAvailable.Name.Default" ) );
@@ -121,7 +121,7 @@ public class ActionWebServiceAvailableDialog extends ActionDialog implements IAc
     fdlURL.right = new FormAttachment( middle, -margin );
     wlURL.setLayoutData(fdlURL);
 
-    wURL = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wURL = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wURL );
     wURL.addModifyListener( lsMod );
     FormData fdURL = new FormData();
@@ -131,7 +131,7 @@ public class ActionWebServiceAvailableDialog extends ActionDialog implements IAc
     wURL.setLayoutData(fdURL);
 
     // Whenever something changes, set the tooltip to the expanded version:
-    wURL.addModifyListener( e -> wURL.setToolTipText( workflowMeta.environmentSubstitute( wURL.getText() ) ) );
+    wURL.addModifyListener( e -> wURL.setToolTipText( getWorkflowMeta().environmentSubstitute( wURL.getText() ) ) );
 
     // connect timeout line
     Label wlConnectTimeOut = new Label(shell, SWT.RIGHT);
@@ -143,7 +143,7 @@ public class ActionWebServiceAvailableDialog extends ActionDialog implements IAc
     fdlConnectTimeOut.right = new FormAttachment( middle, -margin );
     wlConnectTimeOut.setLayoutData(fdlConnectTimeOut);
 
-    wConnectTimeOut = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wConnectTimeOut = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     wConnectTimeOut.setToolTipText( BaseMessages.getString(
       PKG, "ActionWebServiceAvailable.ConnectTimeOut.Tooltip" ) );
     props.setLook( wConnectTimeOut );
@@ -155,7 +155,7 @@ public class ActionWebServiceAvailableDialog extends ActionDialog implements IAc
     wConnectTimeOut.setLayoutData(fdConnectTimeOut);
 
     // Whenever something changes, set the tooltip to the expanded version:
-    wConnectTimeOut.addModifyListener( e -> wConnectTimeOut.setToolTipText( workflowMeta.environmentSubstitute( wConnectTimeOut.getText() ) ) );
+    wConnectTimeOut.addModifyListener( e -> wConnectTimeOut.setToolTipText( getWorkflowMeta().environmentSubstitute( wConnectTimeOut.getText() ) ) );
 
     // Read timeout line
     Label wlReadTimeOut = new Label(shell, SWT.RIGHT);
@@ -167,7 +167,7 @@ public class ActionWebServiceAvailableDialog extends ActionDialog implements IAc
     fdlReadTimeOut.right = new FormAttachment( middle, -margin );
     wlReadTimeOut.setLayoutData(fdlReadTimeOut);
 
-    wReadTimeOut = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wReadTimeOut = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     wReadTimeOut.setToolTipText( BaseMessages.getString( PKG, "ActionWebServiceAvailable.ReadTimeOut.Tooltip" ) );
     props.setLook( wReadTimeOut );
     wReadTimeOut.addModifyListener( lsMod );
@@ -178,7 +178,7 @@ public class ActionWebServiceAvailableDialog extends ActionDialog implements IAc
     wReadTimeOut.setLayoutData(fdReadTimeOut);
 
     // Whenever something changes, set the tooltip to the expanded version:
-    wReadTimeOut.addModifyListener( e -> wReadTimeOut.setToolTipText( workflowMeta.environmentSubstitute( wReadTimeOut.getText() ) ) );
+    wReadTimeOut.addModifyListener( e -> wReadTimeOut.setToolTipText( getWorkflowMeta().environmentSubstitute( wReadTimeOut.getText() ) ) );
 
     Button wOk = new Button(shell, SWT.PUSH);
     wOk.setText( BaseMessages.getString( PKG, "System.Button.OK" ) );

--- a/plugins/actions/writetofile/src/main/java/org/apache/hop/workflow/actions/writetofile/ActionWriteToFileDialog.java
+++ b/plugins/actions/writetofile/src/main/java/org/apache/hop/workflow/actions/writetofile/ActionWriteToFileDialog.java
@@ -78,7 +78,7 @@ public class ActionWriteToFileDialog extends ActionDialog implements IActionDial
   private boolean gotEncodings = false;
 
   public ActionWriteToFileDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionWriteToFile) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "JobWriteToFile.Name.Default" ) );
@@ -162,7 +162,7 @@ public class ActionWriteToFileDialog extends ActionDialog implements IActionDial
     fdbFilename.top = new FormAttachment( wName, 0 );
     wbFilename.setLayoutData(fdbFilename);
 
-    wFilename = new TextVar( workflowMeta, wFileGroup, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wFilename = new TextVar( getWorkflowMeta(), wFileGroup, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wFilename );
     wFilename.addModifyListener( lsMod );
     FormData fdFilename = new FormData();
@@ -172,9 +172,9 @@ public class ActionWriteToFileDialog extends ActionDialog implements IActionDial
     wFilename.setLayoutData(fdFilename);
 
     // Whenever something changes, set the tooltip to the expanded version:
-    wFilename.addModifyListener( e -> wFilename.setToolTipText( workflowMeta.environmentSubstitute( wFilename.getText() ) ) );
+    wFilename.addModifyListener( e -> wFilename.setToolTipText( getWorkflowMeta().environmentSubstitute( wFilename.getText() ) ) );
 
-    wbFilename.addListener( SWT.Selection, e-> BaseDialog.presentFileDialog( shell, wFilename, workflowMeta,
+    wbFilename.addListener( SWT.Selection, e-> BaseDialog.presentFileDialog( shell, wFilename, getWorkflowMeta(),
       new String[] { "*" }, FILETYPES, true )
     );
 
@@ -255,7 +255,7 @@ public class ActionWriteToFileDialog extends ActionDialog implements IActionDial
     fdlEncoding.top = new FormAttachment( wAppendFile, margin );
     fdlEncoding.right = new FormAttachment( middle, -margin );
     wlEncoding.setLayoutData(fdlEncoding);
-    wEncoding = new ComboVar( workflowMeta, wContentGroup, SWT.BORDER | SWT.READ_ONLY );
+    wEncoding = new ComboVar( getWorkflowMeta(), wContentGroup, SWT.BORDER | SWT.READ_ONLY );
     wEncoding.setEditable( true );
     props.setLook( wEncoding );
     wEncoding.addModifyListener( lsMod );

--- a/plugins/actions/writetolog/src/main/java/org/apache/hop/workflow/actions/writetolog/ActionWriteToLogDialog.java
+++ b/plugins/actions/writetolog/src/main/java/org/apache/hop/workflow/actions/writetolog/ActionWriteToLogDialog.java
@@ -68,7 +68,7 @@ public class ActionWriteToLogDialog extends ActionDialog implements IActionDialo
   private CCombo wLoglevel;
 
   public ActionWriteToLogDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionWriteToLog) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "WriteToLog.Name.Default" ) );
@@ -151,7 +151,7 @@ public class ActionWriteToLogDialog extends ActionDialog implements IActionDialo
     fdlLogSubject.right = new FormAttachment( middle, -margin );
     wlLogSubject.setLayoutData(fdlLogSubject);
 
-    wLogSubject = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wLogSubject = new TextVar( getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     wLogSubject.setText( BaseMessages.getString( PKG, "WriteToLog.Name.Default" ) );
     props.setLook( wLogSubject );
     wLogSubject.addModifyListener( lsMod );
@@ -183,7 +183,7 @@ public class ActionWriteToLogDialog extends ActionDialog implements IActionDialo
     wLogMessage.setLayoutData(fdLogMessage);
 
     // SelectionAdapter lsVar = VariableButtonListenerFactory.getSelectionAdapter(shell, wLogMessage, workflowMeta);
-    wLogMessage.addKeyListener( new ControlSpaceKeyAdapter( workflowMeta, wLogMessage ) );
+    wLogMessage.addKeyListener( new ControlSpaceKeyAdapter( getWorkflowMeta(), wLogMessage ) );
 
     // Add listeners
     Listener lsCancel = e -> cancel();

--- a/plugins/actions/xml/src/main/java/org/apache/hop/workflow/actions/xml/dtdvalidator/DtdValidatorDialog.java
+++ b/plugins/actions/xml/src/main/java/org/apache/hop/workflow/actions/xml/dtdvalidator/DtdValidatorDialog.java
@@ -69,17 +69,17 @@ public class DtdValidatorDialog extends ActionDialog implements IActionDialog {
 
   private Button wDTDIntern;
 
-  private DtdValidator jobEntry;
+  private DtdValidator action;
 
   private Shell shell;
 
   private boolean changed;
 
-  public DtdValidatorDialog(Shell parent, IAction jobEntryInt, WorkflowMeta jobMeta ) {
-    super( parent, jobEntryInt, jobMeta );
-    jobEntry = (DtdValidator) jobEntryInt;
-    if ( this.jobEntry.getName() == null ) {
-      this.jobEntry.setName( BaseMessages.getString( PKG, "JobEntryDTDValidator.Name.Default" ) );
+  public DtdValidatorDialog(Shell parent, IAction action, WorkflowMeta jobMeta ) {
+    super( parent, jobMeta );
+    action = (DtdValidator) action;
+    if ( this.action.getName() == null ) {
+      this.action.setName( BaseMessages.getString( PKG, "JobEntryDTDValidator.Name.Default" ) );
     }
   }
 
@@ -89,10 +89,12 @@ public class DtdValidatorDialog extends ActionDialog implements IActionDialog {
 
     shell = new Shell( parent, SWT.DIALOG_TRIM | SWT.MIN | SWT.MAX | SWT.RESIZE );
     props.setLook( shell );
-    WorkflowDialog.setShellImage( shell, jobEntry );
+    WorkflowDialog.setShellImage( shell, action );
 
-    ModifyListener lsMod = e -> jobEntry.setChanged();
-    changed = jobEntry.hasChanged();
+    WorkflowMeta workflowMeta = getWorkflowMeta();
+    
+    ModifyListener lsMod = e -> action.setChanged();
+    changed = action.hasChanged();
 
     FormLayout formLayout = new FormLayout();
     formLayout.marginWidth = Const.FORM_MARGIN;
@@ -185,7 +187,7 @@ public class DtdValidatorDialog extends ActionDialog implements IActionDialog {
     wDTDIntern.addSelectionListener( new SelectionAdapter() {
       public void widgetSelected( SelectionEvent e ) {
         ActiveDTDFilename();
-        jobEntry.setChanged();
+        action.setChanged();
       }
     } );
 
@@ -273,7 +275,7 @@ public class DtdValidatorDialog extends ActionDialog implements IActionDialog {
         display.sleep();
       }
     }
-    return jobEntry;
+    return action;
   }
 
   public void dispose() {
@@ -292,24 +294,24 @@ public class DtdValidatorDialog extends ActionDialog implements IActionDialog {
    * Copy information from the meta-data input to the dialog fields.
    */
   public void getData() {
-    if ( jobEntry.getName() != null ) {
-      wName.setText( jobEntry.getName() );
+    if ( action.getName() != null ) {
+      wName.setText( action.getName() );
     }
-    if ( jobEntry.getxmlFilename() != null ) {
-      wxmlFilename.setText( jobEntry.getxmlFilename() );
+    if ( action.getxmlFilename() != null ) {
+      wxmlFilename.setText( action.getxmlFilename() );
     }
-    if ( jobEntry.getdtdFilename() != null ) {
-      wdtdFilename.setText( jobEntry.getdtdFilename() );
+    if ( action.getdtdFilename() != null ) {
+      wdtdFilename.setText( action.getdtdFilename() );
     }
-    wDTDIntern.setSelection( jobEntry.getDTDIntern() );
+    wDTDIntern.setSelection( action.getDTDIntern() );
 
     wName.selectAll();
     wName.setFocus();
   }
 
   private void cancel() {
-    jobEntry.setChanged( changed );
-    jobEntry = null;
+    action.setChanged( changed );
+    action = null;
     dispose();
   }
 
@@ -321,11 +323,11 @@ public class DtdValidatorDialog extends ActionDialog implements IActionDialog {
       mb.open();
       return;
     }
-    jobEntry.setName( wName.getText() );
-    jobEntry.setxmlFilename( wxmlFilename.getText() );
-    jobEntry.setdtdFilename( wdtdFilename.getText() );
+    action.setName( wName.getText() );
+    action.setxmlFilename( wxmlFilename.getText() );
+    action.setdtdFilename( wdtdFilename.getText() );
 
-    jobEntry.setDTDIntern( wDTDIntern.getSelection() );
+    action.setDTDIntern( wDTDIntern.getSelection() );
 
     dispose();
   }

--- a/plugins/actions/xml/src/main/java/org/apache/hop/workflow/actions/xml/xmlwellformed/XmlWellFormedDialog.java
+++ b/plugins/actions/xml/src/main/java/org/apache/hop/workflow/actions/xml/xmlwellformed/XmlWellFormedDialog.java
@@ -68,7 +68,7 @@ public class XmlWellFormedDialog extends ActionDialog implements IActionDialog {
 
   private Button wIncludeSubfolders;
 
-  private XmlWellFormed jobEntry;
+  private XmlWellFormed action;
   private Shell shell;
 
   private boolean changed;
@@ -93,12 +93,12 @@ public class XmlWellFormedDialog extends ActionDialog implements IActionDialog {
   private Label wlNrErrorsLessThan;
   private TextVar wNrErrorsLessThan;
 
-  public XmlWellFormedDialog(Shell parent, IAction jobEntryInt, WorkflowMeta workflowMeta ) {
-    super( parent, jobEntryInt, workflowMeta );
-    jobEntry = (XmlWellFormed) jobEntryInt;
+  public XmlWellFormedDialog(Shell parent, IAction action, WorkflowMeta workflowMeta ) {
+    super( parent, workflowMeta );
+    action = (XmlWellFormed) action;
 
-    if ( this.jobEntry.getName() == null ) {
-      this.jobEntry.setName( BaseMessages.getString( PKG, "JobXMLWellFormed.Name.Default" ) );
+    if ( this.action.getName() == null ) {
+      this.action.setName( BaseMessages.getString( PKG, "JobXMLWellFormed.Name.Default" ) );
     }
   }
 
@@ -108,10 +108,12 @@ public class XmlWellFormedDialog extends ActionDialog implements IActionDialog {
 
     shell = new Shell( parent, SWT.DIALOG_TRIM | SWT.MIN | SWT.MAX | SWT.RESIZE );
     props.setLook( shell );
-    WorkflowDialog.setShellImage( shell, jobEntry );
+    WorkflowDialog.setShellImage( shell, action );
 
-    ModifyListener lsMod = e -> jobEntry.setChanged();
-    changed = jobEntry.hasChanged();
+    WorkflowMeta workflowMeta = getWorkflowMeta();
+    
+    ModifyListener lsMod = e -> action.setChanged();
+    changed = action.hasChanged();
 
     FormLayout formLayout = new FormLayout();
     formLayout.marginWidth = Const.FORM_MARGIN;
@@ -191,7 +193,7 @@ public class XmlWellFormedDialog extends ActionDialog implements IActionDialog {
     wIncludeSubfolders.setLayoutData(fdIncludeSubfolders);
     wIncludeSubfolders.addSelectionListener( new SelectionAdapter() {
       public void widgetSelected( SelectionEvent e ) {
-        jobEntry.setChanged();
+        action.setChanged();
       }
     } );
 
@@ -206,7 +208,7 @@ public class XmlWellFormedDialog extends ActionDialog implements IActionDialog {
     wlPrevious.setLayoutData(fdlPrevious);
     wPrevious = new Button(wSettings, SWT.CHECK );
     props.setLook( wPrevious );
-    wPrevious.setSelection( jobEntry.isArgFromPrevious() );
+    wPrevious.setSelection( action.isArgFromPrevious() );
     wPrevious.setToolTipText( BaseMessages.getString( PKG, "JobXMLWellFormed.Previous.Tooltip" ) );
     FormData fdPrevious = new FormData();
     fdPrevious.left = new FormAttachment( middle, 0 );
@@ -364,7 +366,7 @@ public class XmlWellFormedDialog extends ActionDialog implements IActionDialog {
     wlFields.setLayoutData(fdlFields);
 
     int rows =
-        jobEntry.getSourceFileFolders() == null ? 1 : ( jobEntry.getSourceFileFolders().length == 0 ? 0 : jobEntry
+        action.getSourceFileFolders() == null ? 1 : ( action.getSourceFileFolders().length == 0 ? 0 : action
             .getSourceFileFolders().length );
     final int FieldsRows = rows;
 
@@ -650,7 +652,7 @@ public class XmlWellFormedDialog extends ActionDialog implements IActionDialog {
         display.sleep();
       }
     }
-    return jobEntry;
+    return action;
   }
 
   private void activeSuccessCondition() {
@@ -684,31 +686,31 @@ public class XmlWellFormedDialog extends ActionDialog implements IActionDialog {
    * Copy information from the meta-data input to the dialog fields.
    */
   public void getData() {
-    wName.setText( Const.nullToEmpty( jobEntry.getName() ) );
+    wName.setText( Const.nullToEmpty( action.getName() ) );
 
-    if ( jobEntry.getSourceFileFolders() != null ) {
-      for ( int i = 0; i < jobEntry.getSourceFileFolders().length; i++ ) {
+    if ( action.getSourceFileFolders() != null ) {
+      for ( int i = 0; i < action.getSourceFileFolders().length; i++ ) {
         TableItem ti = wFields.table.getItem( i );
-        if ( jobEntry.getSourceFileFolders()[i] != null ) {
-          ti.setText( 1, jobEntry.getSourceFileFolders()[i] );
+        if ( action.getSourceFileFolders()[i] != null ) {
+          ti.setText( 1, action.getSourceFileFolders()[i] );
         }
 
-        if ( jobEntry.getSourceWildcards()[i] != null ) {
-          ti.setText( 2, jobEntry.getSourceWildcards()[i] );
+        if ( action.getSourceWildcards()[i] != null ) {
+          ti.setText( 2, action.getSourceWildcards()[i] );
         }
       }
       wFields.setRowNums();
       wFields.optWidth( true );
     }
-    wPrevious.setSelection( jobEntry.isArgFromPrevious() );
-    wIncludeSubfolders.setSelection( jobEntry.isIncludeSubfolders() );
+    wPrevious.setSelection( action.isArgFromPrevious() );
+    wIncludeSubfolders.setSelection( action.isIncludeSubfolders() );
 
-    wNrErrorsLessThan.setText( Const.NVL( jobEntry.getNrErrorsLessThan(), "10" ) );
+    wNrErrorsLessThan.setText( Const.NVL( action.getNrErrorsLessThan(), "10" ) );
 
-    if ( jobEntry.getSuccessCondition() != null ) {
-      if ( jobEntry.getSuccessCondition().equals( XmlWellFormed.SUCCESS_IF_AT_LEAST_X_FILES_WELL_FORMED ) ) {
+    if ( action.getSuccessCondition() != null ) {
+      if ( action.getSuccessCondition().equals( XmlWellFormed.SUCCESS_IF_AT_LEAST_X_FILES_WELL_FORMED ) ) {
         wSuccessCondition.select( 1 );
-      } else if ( jobEntry.getSuccessCondition().equals( XmlWellFormed.SUCCESS_IF_BAD_FORMED_FILES_LESS ) ) {
+      } else if ( action.getSuccessCondition().equals( XmlWellFormed.SUCCESS_IF_BAD_FORMED_FILES_LESS ) ) {
         wSuccessCondition.select( 2 );
       } else {
         wSuccessCondition.select( 0 );
@@ -717,10 +719,10 @@ public class XmlWellFormedDialog extends ActionDialog implements IActionDialog {
       wSuccessCondition.select( 0 );
     }
 
-    if ( jobEntry.getResultFilenames() != null ) {
-      if ( jobEntry.getResultFilenames().equals( XmlWellFormed.ADD_WELL_FORMED_FILES_ONLY ) ) {
+    if ( action.getResultFilenames() != null ) {
+      if ( action.getResultFilenames().equals( XmlWellFormed.ADD_WELL_FORMED_FILES_ONLY ) ) {
         wAddFilenameToResult.select( 1 );
-      } else if ( jobEntry.getResultFilenames().equals( XmlWellFormed.ADD_BAD_FORMED_FILES_ONLY ) ) {
+      } else if ( action.getResultFilenames().equals( XmlWellFormed.ADD_BAD_FORMED_FILES_ONLY ) ) {
         wAddFilenameToResult.select( 2 );
       } else {
         wAddFilenameToResult.select( 0 );
@@ -734,8 +736,8 @@ public class XmlWellFormedDialog extends ActionDialog implements IActionDialog {
   }
 
   private void cancel() {
-    jobEntry.setChanged( changed );
-    jobEntry = null;
+    action.setChanged( changed );
+    action = null;
     dispose();
   }
 
@@ -747,27 +749,27 @@ public class XmlWellFormedDialog extends ActionDialog implements IActionDialog {
       mb.open();
       return;
     }
-    jobEntry.setName( wName.getText() );
+    action.setName( wName.getText() );
 
-    jobEntry.setIncludeSubfolders( wIncludeSubfolders.getSelection() );
-    jobEntry.setArgFromPrevious( wPrevious.getSelection() );
+    action.setIncludeSubfolders( wIncludeSubfolders.getSelection() );
+    action.setArgFromPrevious( wPrevious.getSelection() );
 
-    jobEntry.setNrErrorsLessThan( wNrErrorsLessThan.getText() );
+    action.setNrErrorsLessThan( wNrErrorsLessThan.getText() );
 
     if ( wSuccessCondition.getSelectionIndex() == 1 ) {
-      jobEntry.setSuccessCondition( XmlWellFormed.SUCCESS_IF_AT_LEAST_X_FILES_WELL_FORMED );
+      action.setSuccessCondition( XmlWellFormed.SUCCESS_IF_AT_LEAST_X_FILES_WELL_FORMED );
     } else if ( wSuccessCondition.getSelectionIndex() == 2 ) {
-      jobEntry.setSuccessCondition( XmlWellFormed.SUCCESS_IF_BAD_FORMED_FILES_LESS );
+      action.setSuccessCondition( XmlWellFormed.SUCCESS_IF_BAD_FORMED_FILES_LESS );
     } else {
-      jobEntry.setSuccessCondition( XmlWellFormed.SUCCESS_IF_NO_ERRORS );
+      action.setSuccessCondition( XmlWellFormed.SUCCESS_IF_NO_ERRORS );
     }
 
     if ( wAddFilenameToResult.getSelectionIndex() == 1 ) {
-      jobEntry.setResultFilenames( XmlWellFormed.ADD_WELL_FORMED_FILES_ONLY );
+      action.setResultFilenames( XmlWellFormed.ADD_WELL_FORMED_FILES_ONLY );
     } else if ( wAddFilenameToResult.getSelectionIndex() == 2 ) {
-      jobEntry.setResultFilenames( XmlWellFormed.ADD_BAD_FORMED_FILES_ONLY );
+      action.setResultFilenames( XmlWellFormed.ADD_BAD_FORMED_FILES_ONLY );
     } else {
-      jobEntry.setResultFilenames( XmlWellFormed.ADD_ALL_FILENAMES );
+      action.setResultFilenames( XmlWellFormed.ADD_ALL_FILENAMES );
     }
 
     int nritems = wFields.nrNonEmpty();
@@ -790,8 +792,8 @@ public class XmlWellFormedDialog extends ActionDialog implements IActionDialog {
         nr++;
       }
     }
-    jobEntry.setSourceFileFolders( source_filefolder );
-    jobEntry.setSourceWildcards( wildcard );
+    action.setSourceFileFolders( source_filefolder );
+    action.setSourceWildcards( wildcard );
     dispose();
   }
 

--- a/plugins/actions/xml/src/main/java/org/apache/hop/workflow/actions/xml/xsdvalidator/XsdValidatorDialog.java
+++ b/plugins/actions/xml/src/main/java/org/apache/hop/workflow/actions/xml/xsdvalidator/XsdValidatorDialog.java
@@ -66,16 +66,16 @@ public class XsdValidatorDialog extends ActionDialog implements IActionDialog {
 
   private TextVar wxsdFilename;
 
-  private XsdValidator jobEntry;
+  private XsdValidator action;
   private Shell shell;
 
   private boolean changed;
 
-  public XsdValidatorDialog(Shell parent, IAction jobEntryInt, WorkflowMeta workflowMeta ) {
-    super( parent, jobEntryInt, workflowMeta );
-    jobEntry = (XsdValidator) jobEntryInt;
-    if ( this.jobEntry.getName() == null ) {
-      this.jobEntry.setName( BaseMessages.getString( PKG, "JobEntryXSDValidator.Name.Default" ) );
+  public XsdValidatorDialog(Shell parent, IAction action, WorkflowMeta workflowMeta ) {
+    super( parent, workflowMeta );
+    action = (XsdValidator) action;
+    if ( this.action.getName() == null ) {
+      this.action.setName( BaseMessages.getString( PKG, "JobEntryXSDValidator.Name.Default" ) );
     }
   }
 
@@ -85,10 +85,12 @@ public class XsdValidatorDialog extends ActionDialog implements IActionDialog {
 
     shell = new Shell( parent, SWT.DIALOG_TRIM | SWT.MIN | SWT.MAX | SWT.RESIZE  );
     props.setLook( shell );
-    WorkflowDialog.setShellImage( shell, jobEntry );
+    WorkflowDialog.setShellImage( shell, action );
 
-    ModifyListener lsMod = e -> jobEntry.setChanged();
-    changed = jobEntry.hasChanged();
+    WorkflowMeta workflowMeta = getWorkflowMeta();
+    
+    ModifyListener lsMod = e -> action.setChanged();
+    changed = action.hasChanged();
 
     FormLayout formLayout = new FormLayout();
     formLayout.marginWidth = Const.FORM_MARGIN;
@@ -137,7 +139,7 @@ public class XsdValidatorDialog extends ActionDialog implements IActionDialog {
 
     wAllowExternalEntities.addSelectionListener( new SelectionAdapter() {
       public void widgetSelected( SelectionEvent e ) {
-        jobEntry.setChanged();
+        action.setChanged();
       }
     } );
 
@@ -267,7 +269,7 @@ public class XsdValidatorDialog extends ActionDialog implements IActionDialog {
         display.sleep();
       }
     }
-    return jobEntry;
+    return action;
   }
 
   public void dispose() {
@@ -280,18 +282,18 @@ public class XsdValidatorDialog extends ActionDialog implements IActionDialog {
    * Copy information from the meta-data input to the dialog fields.
    */
   public void getData() {
-    wName.setText( Const.nullToEmpty( jobEntry.getName() ) );
-    wAllowExternalEntities.setSelection( jobEntry.isAllowExternalEntities() );
-    wxmlFilename.setText( Const.nullToEmpty( jobEntry.getxmlFilename() ) );
-    wxsdFilename.setText( Const.nullToEmpty( jobEntry.getxsdFilename() ) );
+    wName.setText( Const.nullToEmpty( action.getName() ) );
+    wAllowExternalEntities.setSelection( action.isAllowExternalEntities() );
+    wxmlFilename.setText( Const.nullToEmpty( action.getxmlFilename() ) );
+    wxsdFilename.setText( Const.nullToEmpty( action.getxsdFilename() ) );
 
     wName.selectAll();
     wName.setFocus();
   }
 
   private void cancel() {
-    jobEntry.setChanged( changed );
-    jobEntry = null;
+    action.setChanged( changed );
+    action = null;
     dispose();
   }
 
@@ -303,10 +305,10 @@ public class XsdValidatorDialog extends ActionDialog implements IActionDialog {
       mb.open();
       return;
     }
-    jobEntry.setName( wName.getText() );
-    jobEntry.setAllowExternalEntities( wAllowExternalEntities.getSelection() );
-    jobEntry.setxmlFilename( wxmlFilename.getText() );
-    jobEntry.setxsdFilename( wxsdFilename.getText() );
+    action.setName( wName.getText() );
+    action.setAllowExternalEntities( wAllowExternalEntities.getSelection() );
+    action.setxmlFilename( wxmlFilename.getText() );
+    action.setxsdFilename( wxsdFilename.getText() );
 
     dispose();
   }

--- a/plugins/actions/xml/src/main/java/org/apache/hop/workflow/actions/xml/xslt/XsltDialog.java
+++ b/plugins/actions/xml/src/main/java/org/apache/hop/workflow/actions/xml/xslt/XsltDialog.java
@@ -83,7 +83,7 @@ public class XsltDialog extends ActionDialog implements IActionDialog {
 
   private CCombo wIfFileExists;
 
-  private Xslt jobEntry;
+  private Xslt action;
   private Shell shell;
 
   private boolean changed;
@@ -98,11 +98,11 @@ public class XsltDialog extends ActionDialog implements IActionDialog {
 
   private TableView wOutputProperties;
 
-  public XsltDialog(Shell parent, IAction jobEntryInt, WorkflowMeta jobMeta ) {
-    super( parent, jobEntryInt, jobMeta );
-    jobEntry = (Xslt) jobEntryInt;
-    if ( this.jobEntry.getName() == null ) {
-      this.jobEntry.setName( BaseMessages.getString( PKG, "JobEntryXSLT.Name.Default" ) );
+  public XsltDialog(Shell parent, IAction action, WorkflowMeta jobMeta ) {
+    super( parent, jobMeta );
+    action = (Xslt) action;
+    if ( this.action.getName() == null ) {
+      this.action.setName( BaseMessages.getString( PKG, "JobEntryXSLT.Name.Default" ) );
     }
   }
 
@@ -112,10 +112,12 @@ public class XsltDialog extends ActionDialog implements IActionDialog {
 
     shell = new Shell( parent, SWT.DIALOG_TRIM | SWT.MIN | SWT.MAX | SWT.RESIZE );
     props.setLook( shell );
-    WorkflowDialog.setShellImage( shell, jobEntry );
+    WorkflowDialog.setShellImage( shell, action );
 
-    ModifyListener lsMod = e -> jobEntry.setChanged();
-    changed = jobEntry.hasChanged();
+    WorkflowMeta workflowMeta = getWorkflowMeta();
+    
+    ModifyListener lsMod = e -> action.setChanged();
+    changed = action.hasChanged();
 
     FormLayout formLayout = new FormLayout();
     formLayout.marginWidth = Const.FORM_MARGIN;
@@ -453,7 +455,7 @@ public class XsltDialog extends ActionDialog implements IActionDialog {
     wAddFileToResult.setLayoutData(fdAddFileToResult);
     wAddFileToResult.addSelectionListener( new SelectionAdapter() {
       public void widgetSelected( SelectionEvent e ) {
-        jobEntry.setChanged();
+        action.setChanged();
       }
     } );
 
@@ -505,7 +507,7 @@ public class XsltDialog extends ActionDialog implements IActionDialog {
     fdlOutputProperties.top = new FormAttachment( 0, margin );
     wlOutputProperties.setLayoutData(fdlOutputProperties);
 
-    final int OutputPropertiesRows = jobEntry.getOutputPropertyName().length;
+    final int OutputPropertiesRows = action.getOutputPropertyName().length;
 
     ColumnInfo[] colinf = new ColumnInfo[]{
             new ColumnInfo(BaseMessages.getString(PKG, "XsltDialog.ColumnInfo.OutputProperties.Name"),
@@ -535,7 +537,7 @@ public class XsltDialog extends ActionDialog implements IActionDialog {
     fdlFields.top = new FormAttachment( wOutputProperties, 2 * margin );
     wlFields.setLayoutData(fdlFields);
 
-    final int FieldsRows = jobEntry.getParameterField().length;
+    final int FieldsRows = action.getParameterField().length;
 
     colinf =
         new ColumnInfo[] {
@@ -619,7 +621,7 @@ public class XsltDialog extends ActionDialog implements IActionDialog {
         display.sleep();
       }
     }
-    return jobEntry;
+    return action;
   }
 
   private void RefreshArgFromPrevious() {
@@ -644,36 +646,36 @@ public class XsltDialog extends ActionDialog implements IActionDialog {
    * Copy information from the meta-data input to the dialog fields.
    */
   public void getData() {
-    wName.setText( Const.nullToEmpty( jobEntry.getName() ) );
-    wxmlFilename.setText( Const.nullToEmpty( jobEntry.getxmlFilename() ) );
-    wxslFilename.setText( Const.nullToEmpty( jobEntry.getxslFilename() ) );
-    wOutputFilename.setText( Const.nullToEmpty( jobEntry.getoutputFilename() ) );
+    wName.setText( Const.nullToEmpty( action.getName() ) );
+    wxmlFilename.setText( Const.nullToEmpty( action.getxmlFilename() ) );
+    wxslFilename.setText( Const.nullToEmpty( action.getxslFilename() ) );
+    wOutputFilename.setText( Const.nullToEmpty( action.getoutputFilename() ) );
 
-    if ( jobEntry.iffileexists >= 0 ) {
-      wIfFileExists.select( jobEntry.iffileexists );
+    if ( action.iffileexists >= 0 ) {
+      wIfFileExists.select( action.iffileexists );
     } else {
       wIfFileExists.select( 2 ); // NOTHING
     }
 
-    wAddFileToResult.setSelection( jobEntry.isAddFileToResult() );
-    wPrevious.setSelection( jobEntry.isFilenamesFromPrevious() );
-    if ( jobEntry.getXSLTFactory() != null ) {
-      wXSLTFactory.setText( jobEntry.getXSLTFactory() );
+    wAddFileToResult.setSelection( action.isAddFileToResult() );
+    wPrevious.setSelection( action.isFilenamesFromPrevious() );
+    if ( action.getXSLTFactory() != null ) {
+      wXSLTFactory.setText( action.getXSLTFactory() );
     } else {
       wXSLTFactory.setText( "JAXP" );
     }
-    if ( jobEntry.getParameterName() != null ) {
-      for ( int i = 0; i < jobEntry.getParameterName().length; i++ ) {
+    if ( action.getParameterName() != null ) {
+      for ( int i = 0; i < action.getParameterName().length; i++ ) {
         TableItem item = wFields.table.getItem( i );
-        item.setText( 1, Const.NVL( jobEntry.getParameterField()[i], "" ) );
-        item.setText( 2, Const.NVL( jobEntry.getParameterName()[i], "" ) );
+        item.setText( 1, Const.NVL( action.getParameterField()[i], "" ) );
+        item.setText( 2, Const.NVL( action.getParameterName()[i], "" ) );
       }
     }
-    if ( jobEntry.getOutputPropertyName() != null ) {
-      for ( int i = 0; i < jobEntry.getOutputPropertyName().length; i++ ) {
+    if ( action.getOutputPropertyName() != null ) {
+      for ( int i = 0; i < action.getOutputPropertyName().length; i++ ) {
         TableItem item = wOutputProperties.table.getItem( i );
-        item.setText( 1, Const.NVL( jobEntry.getOutputPropertyName()[i], "" ) );
-        item.setText( 2, Const.NVL( jobEntry.getOutputPropertyValue()[i], "" ) );
+        item.setText( 1, Const.NVL( action.getOutputPropertyName()[i], "" ) );
+        item.setText( 2, Const.NVL( action.getOutputPropertyValue()[i], "" ) );
       }
     }
 
@@ -682,8 +684,8 @@ public class XsltDialog extends ActionDialog implements IActionDialog {
   }
 
   private void cancel() {
-    jobEntry.setChanged( changed );
-    jobEntry = null;
+    action.setChanged( changed );
+    action = null;
     dispose();
   }
 
@@ -695,29 +697,29 @@ public class XsltDialog extends ActionDialog implements IActionDialog {
       mb.open();
       return;
     }
-    jobEntry.setName( wName.getText() );
-    jobEntry.setxmlFilename( wxmlFilename.getText() );
-    jobEntry.setxslFilename( wxslFilename.getText() );
-    jobEntry.setoutputFilename( wOutputFilename.getText() );
-    jobEntry.iffileexists = wIfFileExists.getSelectionIndex();
-    jobEntry.setFilenamesFromPrevious( wPrevious.getSelection() );
-    jobEntry.setAddFileToResult( wAddFileToResult.getSelection() );
-    jobEntry.setXSLTFactory( wXSLTFactory.getText() );
+    action.setName( wName.getText() );
+    action.setxmlFilename( wxmlFilename.getText() );
+    action.setxslFilename( wxslFilename.getText() );
+    action.setoutputFilename( wOutputFilename.getText() );
+    action.iffileexists = wIfFileExists.getSelectionIndex();
+    action.setFilenamesFromPrevious( wPrevious.getSelection() );
+    action.setAddFileToResult( wAddFileToResult.getSelection() );
+    action.setXSLTFactory( wXSLTFactory.getText() );
 
     int nrparams = wFields.nrNonEmpty();
     int nroutputprops = wOutputProperties.nrNonEmpty();
-    jobEntry.allocate( nrparams, nroutputprops );
+    action.allocate( nrparams, nroutputprops );
 
     // CHECKSTYLE:Indentation:OFF
     for ( int i = 0; i < nrparams; i++ ) {
       TableItem item = wFields.getNonEmpty( i );
-      jobEntry.getParameterField()[i] = item.getText( 1 );
-      jobEntry.getParameterName()[i] = item.getText( 2 );
+      action.getParameterField()[i] = item.getText( 1 );
+      action.getParameterName()[i] = item.getText( 2 );
     }
     for ( int i = 0; i < nroutputprops; i++ ) {
       TableItem item = wOutputProperties.getNonEmpty( i );
-      jobEntry.getOutputPropertyName()[i] = item.getText( 1 );
-      jobEntry.getOutputPropertyValue()[i] = item.getText( 2 );
+      action.getOutputPropertyName()[i] = item.getText( 1 );
+      action.getOutputPropertyValue()[i] = item.getText( 2 );
     }
 
     dispose();

--- a/plugins/actions/zipfile/src/main/java/org/apache/hop/workflow/actions/zipfile/ActionZipFileDialog.java
+++ b/plugins/actions/zipfile/src/main/java/org/apache/hop/workflow/actions/zipfile/ActionZipFileDialog.java
@@ -131,7 +131,7 @@ public class ActionZipFileDialog extends ActionDialog implements IActionDialog {
   private boolean changed;
 
   public ActionZipFileDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionZipFile) action;
     if ( this.action.getName() == null ) {
       this.action.setName( BaseMessages.getString( PKG, "JobZipFiles.Name.Default" ) );
@@ -264,7 +264,7 @@ public class ActionZipFileDialog extends ActionDialog implements IActionDialog {
     wbSourceFile.setLayoutData(fdbSourceFile);
 
     wSourceDirectory =
-      new TextVar( workflowMeta, wSourceFiles, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
+      new TextVar( getWorkflowMeta(), wSourceFiles, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
         PKG, "JobZipFiles.SourceDir.Tooltip" ) );
     props.setLook( wSourceDirectory );
     wSourceDirectory.addModifyListener( lsMod );
@@ -284,7 +284,7 @@ public class ActionZipFileDialog extends ActionDialog implements IActionDialog {
     fdlWildcard.right = new FormAttachment( middle, -margin );
     wlWildcard.setLayoutData(fdlWildcard);
     wWildcard =
-      new TextVar( workflowMeta, wSourceFiles, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
+      new TextVar( getWorkflowMeta(), wSourceFiles, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
         PKG, "JobZipFiles.Wildcard.Tooltip" ) );
     props.setLook( wWildcard );
     wWildcard.addModifyListener( lsMod );
@@ -304,7 +304,7 @@ public class ActionZipFileDialog extends ActionDialog implements IActionDialog {
     fdlWildcardExclude.right = new FormAttachment( middle, -margin );
     wlWildcardExclude.setLayoutData(fdlWildcardExclude);
     wWildcardExclude =
-      new TextVar( workflowMeta, wSourceFiles, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
+      new TextVar( getWorkflowMeta(), wSourceFiles, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
         PKG, "JobZipFiles.WildcardExclude.Tooltip" ) );
     props.setLook( wWildcardExclude );
     wWildcardExclude.addModifyListener( lsMod );
@@ -377,7 +377,7 @@ public class ActionZipFileDialog extends ActionDialog implements IActionDialog {
     fdbZipFilename.right = new FormAttachment( 100, 0 );
     fdbZipFilename.top = new FormAttachment(wSourceFiles, 0 );
     wbZipFilename.setLayoutData(fdbZipFilename);
-    wZipFilename = new TextVar( workflowMeta, wZipFile, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wZipFilename = new TextVar( getWorkflowMeta(), wZipFile, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wZipFilename );
     wZipFilename.addModifyListener( lsMod );
     FormData fdZipFilename = new FormData();
@@ -387,9 +387,9 @@ public class ActionZipFileDialog extends ActionDialog implements IActionDialog {
     wZipFilename.setLayoutData(fdZipFilename);
 
     // Whenever something changes, set the tooltip to the expanded version:
-    wZipFilename.addModifyListener( e -> wZipFilename.setToolTipText( workflowMeta.environmentSubstitute( wZipFilename.getText() ) ) );
+    wZipFilename.addModifyListener( e -> wZipFilename.setToolTipText( getWorkflowMeta().environmentSubstitute( wZipFilename.getText() ) ) );
 
-    wbZipFilename.addListener( SWT.Selection, e-> BaseDialog.presentFileDialog( shell, wZipFilename, workflowMeta,
+    wbZipFilename.addListener( SWT.Selection, e-> BaseDialog.presentFileDialog( shell, wZipFilename, getWorkflowMeta(),
       new String[] { "*.zip;*.ZIP", "*" }, FILETYPES, true )
     );
 
@@ -688,7 +688,7 @@ public class ActionZipFileDialog extends ActionDialog implements IActionDialog {
     wbMovetoDirectory.setLayoutData(fdbMovetoDirectory);
 
     wMovetoDirectory =
-      new TextVar( workflowMeta, wSettings, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
+      new TextVar( getWorkflowMeta(), wSettings, SWT.SINGLE | SWT.LEFT | SWT.BORDER, BaseMessages.getString(
         PKG, "JobZipFiles.MovetoDirectory.Tooltip" ) );
     props.setLook( wMovetoDirectory );
     wMovetoDirectory.addModifyListener( lsMod );
@@ -730,7 +730,7 @@ public class ActionZipFileDialog extends ActionDialog implements IActionDialog {
     fdlStoredSourcePathDepth.top = new FormAttachment( wCreateMoveToDirectory, margin );
     fdlStoredSourcePathDepth.right = new FormAttachment( middle, -margin );
     wlStoredSourcePathDepth.setLayoutData(fdlStoredSourcePathDepth);
-    wStoredSourcePathDepth = new ComboVar( workflowMeta, wSettings, SWT.SINGLE | SWT.BORDER );
+    wStoredSourcePathDepth = new ComboVar( getWorkflowMeta(), wSettings, SWT.SINGLE | SWT.BORDER );
     props.setLook( wStoredSourcePathDepth );
     wStoredSourcePathDepth.setToolTipText( BaseMessages.getString(
       PKG, "JobZipFiles.StoredSourcePathDepth.Tooltip" ) );
@@ -843,9 +843,9 @@ public class ActionZipFileDialog extends ActionDialog implements IActionDialog {
       }
     };
 
-    wbSourceDirectory.addListener( SWT.Selection, e-> BaseDialog.presentDirectoryDialog( shell, wSourceDirectory, workflowMeta ) );
-    wbMovetoDirectory.addListener( SWT.Selection, e-> BaseDialog.presentDirectoryDialog( shell, wMovetoDirectory, workflowMeta ) );
-    wbSourceFile.addListener( SWT.Selection, e-> BaseDialog.presentFileDialog( shell, wSourceDirectory, workflowMeta,
+    wbSourceDirectory.addListener( SWT.Selection, e-> BaseDialog.presentDirectoryDialog( shell, wSourceDirectory, getWorkflowMeta() ) );
+    wbMovetoDirectory.addListener( SWT.Selection, e-> BaseDialog.presentDirectoryDialog( shell, wMovetoDirectory, getWorkflowMeta() ) );
+    wbSourceFile.addListener( SWT.Selection, e-> BaseDialog.presentFileDialog( shell, wSourceDirectory, getWorkflowMeta(),
       new String[] { "*" }, FILETYPES, true )
     );
 

--- a/ui/src/main/java/org/apache/hop/ui/workflow/action/ActionDialog.java
+++ b/ui/src/main/java/org/apache/hop/ui/workflow/action/ActionDialog.java
@@ -27,13 +27,11 @@ import org.apache.hop.core.logging.ILoggingObject;
 import org.apache.hop.core.logging.LoggingObjectType;
 import org.apache.hop.core.logging.SimpleLoggingObject;
 import org.apache.hop.i18n.BaseMessages;
+import org.apache.hop.metadata.api.IHopMetadataProvider;
+import org.apache.hop.ui.core.PropsUi;
+import org.apache.hop.ui.core.widget.MetaSelectionLine;
 import org.apache.hop.workflow.WorkflowMeta;
 import org.apache.hop.workflow.action.IAction;
-import org.apache.hop.metadata.api.IHopMetadataProvider;
-import org.apache.hop.pipeline.transform.ITransform;
-import org.apache.hop.ui.core.PropsUi;
-import org.apache.hop.ui.core.database.dialog.DatabaseDialog;
-import org.apache.hop.ui.core.widget.MetaSelectionLine;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.widgets.Composite;
@@ -58,7 +56,7 @@ public class ActionDialog extends Dialog {
   /**
    * The package name, used for internationalization.
    */
-  private static Class<?> PKG = ITransform.class; // for i18n purposes, needed by Translator!!
+  private static final Class<?> PKG = IAction.class; // for i18n purposes, needed by Translator!!
 
   /**
    * The loggingObject for the dialog
@@ -66,24 +64,14 @@ public class ActionDialog extends Dialog {
   public static final ILoggingObject loggingObject = new SimpleLoggingObject( "Action dialog", LoggingObjectType.ACTION_DIALOG, null );
 
   /**
-   * A reference to the action interface
+   * The Metadata provider
    */
-  protected IAction action;
-
-  /**
-   * the MetaStore
-   */
-  protected IHopMetadataProvider metadataProvider;
+  private IHopMetadataProvider metadataProvider;
 
   /**
    * The workflow metadata object.
    */
-  protected WorkflowMeta workflowMeta;
-
-  /**
-   * A reference to the shell object
-   */
-  protected Shell shell;
+  private WorkflowMeta workflowMeta;
 
   /**
    * A reference to the properties user interface
@@ -91,29 +79,16 @@ public class ActionDialog extends Dialog {
   protected PropsUi props;
 
   /**
-   * A reference to the parent shell
-   */
-  protected Shell parent;
-
-  /**
-   * A reference to a database dialog
-   */
-  protected DatabaseDialog databaseDialog;
-
-  /**
    * Instantiates a new action dialog.
    *
    * @param parent   the parent shell
-   * @param action the action to edit
    * @param workflowMeta  the workflow metadata object
    */
-  public ActionDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
+  public ActionDialog( Shell parent, WorkflowMeta workflowMeta ) {
     super( parent, SWT.NONE );
     props = PropsUi.getInstance();
 
-    this.action = action;
     this.workflowMeta = workflowMeta;
-    this.shell = parent;
   }
 
   /**
@@ -145,5 +120,7 @@ public class ActionDialog extends Dialog {
     this.metadataProvider = metadataProvider;
   }
 
-
+  public WorkflowMeta getWorkflowMeta() {
+	return workflowMeta;
+  }
 }

--- a/ui/src/main/java/org/apache/hop/ui/workflow/actions/missing/MissingActionDialog.java
+++ b/ui/src/main/java/org/apache/hop/ui/workflow/actions/missing/MissingActionDialog.java
@@ -49,24 +49,28 @@ public class MissingActionDialog extends ActionDialog implements IActionDialog {
   private static final Class<?> PKG = MissingActionDialog.class;
 
   private Shell shell;
-  private Shell shellParent;
   private List<MissingAction> missingActions;
   private int mode;
   private PropsUi props;
 
+  /**
+   * A reference to the action interface
+   */
+  protected IAction action;
+  
   public static final int MISSING_ACTIONS = 1;
   public static final int MISSING_ACTION_ID = 2;
 
   public MissingActionDialog( Shell parent, List<MissingAction> missingActions ) {
-    super( parent, null, null );
-    this.shellParent = parent;
+    super( parent, null );
+   
     this.missingActions = missingActions;
     this.mode = MISSING_ACTIONS;
   }
 
   public MissingActionDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
-    this.shellParent = parent;
+    super( parent, workflowMeta );
+    this.action = action;
     this.mode = MISSING_ACTION_ID;
   }
 
@@ -95,11 +99,13 @@ public class MissingActionDialog extends ActionDialog implements IActionDialog {
   public IAction open() {
 
     this.props = PropsUi.getInstance();
-    Display display = shellParent.getDisplay();
+    
+    Shell parent = this.getParent();
+    Display display = parent.getDisplay();
     int margin = props.getMargin();
 
     shell =
-      new Shell( shellParent, SWT.DIALOG_TRIM | SWT.CLOSE | SWT.ICON
+      new Shell( parent, SWT.DIALOG_TRIM | SWT.CLOSE | SWT.ICON
         | SWT.APPLICATION_MODAL );
 
     props.setLook( shell );

--- a/ui/src/main/java/org/apache/hop/ui/workflow/actions/pipeline/ActionBaseDialog.java
+++ b/ui/src/main/java/org/apache/hop/ui/workflow/actions/pipeline/ActionBaseDialog.java
@@ -150,7 +150,7 @@ public abstract class ActionBaseDialog extends ActionDialog {
   public ActionBaseDialog( Shell parent,
                            IAction action,
                            WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     log = new LogChannel( workflowMeta );
   }
 
@@ -211,7 +211,7 @@ public abstract class ActionBaseDialog extends ActionDialog {
     fdBrowse.top = new FormAttachment( wlPath, Const.isOSX() ? 0 : 5 );
     wbBrowse.setLayoutData( fdBrowse );
 
-    wPath = new TextVar( workflowMeta, shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wPath = new TextVar( this.getWorkflowMeta(), shell, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wPath );
     FormData fdPath = new FormData();
     fdPath.left = new FormAttachment( 0, 0 );
@@ -230,7 +230,7 @@ public abstract class ActionBaseDialog extends ActionDialog {
     fdlRunConfiguration.right = new FormAttachment( 50, 0 );
     wlRunConfiguration.setLayoutData( fdlRunConfiguration );
 
-    wRunConfiguration = new ComboVar( workflowMeta, shell, SWT.LEFT | SWT.BORDER );
+    wRunConfiguration = new ComboVar( this.getWorkflowMeta(), shell, SWT.LEFT | SWT.BORDER );
     props.setLook( wlRunConfiguration );
     FormData fdRunConfiguration = new FormData();
     fdRunConfiguration.left = new FormAttachment( wlRunConfiguration, 10 );
@@ -327,7 +327,7 @@ public abstract class ActionBaseDialog extends ActionDialog {
     fdlName.top = new FormAttachment( 0, 0 );
     wlLogfile.setLayoutData( fdlName );
 
-    wLogfile = new TextVar( workflowMeta, gLogFile, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wLogfile = new TextVar( this.getWorkflowMeta(), gLogFile, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wLogfile );
     FormData fdName = new FormData();
     fdName.width = 250;
@@ -351,7 +351,7 @@ public abstract class ActionBaseDialog extends ActionDialog {
     fdlExtension.top = new FormAttachment( wLogfile, 10 );
     wlLogext.setLayoutData( fdlExtension );
 
-    wLogext = new TextVar( workflowMeta, gLogFile, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    wLogext = new TextVar( this.getWorkflowMeta(), gLogFile, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( wLogext );
     FormData fdExtension = new FormData();
     fdExtension.width = 250;
@@ -478,7 +478,7 @@ public abstract class ActionBaseDialog extends ActionDialog {
     colinf[ 2 ].setUsingVariables( true );
 
     wParameters =
-      new TableView( workflowMeta, wParameterComp, SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI, colinf, parameterRows, false,
+      new TableView( this.getWorkflowMeta(), wParameterComp, SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI, colinf, parameterRows, false,
         lsMod, props, false );
     props.setLook( wParameters );
     FormData fdParameters = new FormData();
@@ -547,7 +547,7 @@ public abstract class ActionBaseDialog extends ActionDialog {
 
   protected void selectLogFile( String[] filters ) {
 
-    String filename = BaseDialog.presentFileDialog(shell, wLogfile, workflowMeta,
+    String filename = BaseDialog.presentFileDialog(shell, wLogfile, this.getWorkflowMeta(),
       new String[] { "*.txt", "*.log", "*" },
       filters,
       true

--- a/ui/src/main/java/org/apache/hop/ui/workflow/actions/pipeline/ActionPipelineDialog.java
+++ b/ui/src/main/java/org/apache/hop/ui/workflow/actions/pipeline/ActionPipelineDialog.java
@@ -198,7 +198,7 @@ public class ActionPipelineDialog extends ActionBaseDialog implements IActionDia
             if (inputPipelineMeta == null) {
                 ActionPipeline jet = new ActionPipeline();
                 getInfo(jet);
-                inputPipelineMeta = jet.getPipelineMeta(metadataProvider, workflowMeta);
+                inputPipelineMeta = jet.getPipelineMeta(this.getMetadataProvider(), this.getWorkflowMeta());
             }
             String[] parameters = inputPipelineMeta.listParameters();
 
@@ -224,7 +224,7 @@ public class ActionPipelineDialog extends ActionBaseDialog implements IActionDia
     protected void pickFileVFS() {
 
         HopPipelineFileType<PipelineMeta> pipelineFileType = new HopPipelineFileType<>();
-        String filename = BaseDialog.presentFileDialog(shell, wPath, workflowMeta, pipelineFileType.getFilterExtensions(), pipelineFileType.getFilterNames(), true);
+        String filename = BaseDialog.presentFileDialog(shell, wPath, this.getWorkflowMeta(), pipelineFileType.getFilterExtensions(), pipelineFileType.getFilterNames(), true);
         if (filename != null) {
             wPath.setText(filename);
         }
@@ -287,7 +287,7 @@ public class ActionPipelineDialog extends ActionBaseDialog implements IActionDia
         }
 
         try {
-            List<String> runConfigurations = metadataProvider.getSerializer( PipelineRunConfiguration.class).listObjectNames();
+            List<String> runConfigurations = this.getMetadataProvider().getSerializer( PipelineRunConfiguration.class).listObjectNames();
 
             try {
                 ExtensionPointHandler.callExtensionPoint(HopGui.getInstance().getLog(), HopExtensionPoint.HopUiRunConfiguration.id, new Object[]{runConfigurations, PipelineMeta.XML_TAG});

--- a/ui/src/main/java/org/apache/hop/ui/workflow/actions/special/ActionSpecialDialog.java
+++ b/ui/src/main/java/org/apache/hop/ui/workflow/actions/special/ActionSpecialDialog.java
@@ -25,17 +25,16 @@ package org.apache.hop.ui.workflow.actions.special;
 import org.apache.hop.core.Const;
 import org.apache.hop.i18n.BaseMessages;
 import org.apache.hop.ui.core.gui.GuiResource;
+import org.apache.hop.ui.core.gui.WindowProperty;
+import org.apache.hop.ui.pipeline.transform.BaseTransformDialog;
+import org.apache.hop.ui.workflow.action.ActionDialog;
 import org.apache.hop.ui.workflow.dialog.WorkflowDialog;
 import org.apache.hop.workflow.WorkflowMeta;
-import org.apache.hop.workflow.actions.special.ActionSpecial;
 import org.apache.hop.workflow.action.IAction;
 import org.apache.hop.workflow.action.IActionDialog;
-import org.apache.hop.ui.core.gui.WindowProperty;
-import org.apache.hop.ui.workflow.action.ActionDialog;
-import org.apache.hop.ui.pipeline.transform.BaseTransformDialog;
+import org.apache.hop.workflow.actions.special.ActionSpecial;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CCombo;
-import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
@@ -49,7 +48,6 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Shell;
@@ -104,7 +102,7 @@ public class ActionSpecialDialog extends ActionDialog implements IActionDialog {
   private FormData fdlName, fdName;
 
   public ActionSpecialDialog( Shell parent, IAction action, WorkflowMeta workflowMeta ) {
-    super( parent, action, workflowMeta );
+    super( parent, workflowMeta );
     this.action = (ActionSpecial) action;
   }
 

--- a/ui/src/main/java/org/apache/hop/ui/workflow/actions/workflow/ActionWorkflowDialog.java
+++ b/ui/src/main/java/org/apache/hop/ui/workflow/actions/workflow/ActionWorkflowDialog.java
@@ -214,7 +214,7 @@ public class ActionWorkflowDialog extends ActionBaseDialog implements IActionDia
       if ( inputWorkflowMeta == null ) {
         ActionWorkflow jej = new ActionWorkflow();
         getInfo( jej );
-        inputWorkflowMeta = jej.getWorkflowMeta( metadataProvider, workflowMeta );
+        inputWorkflowMeta = jej.getWorkflowMeta( this.getMetadataProvider(), this.getWorkflowMeta() );
       }
       String[] parameters = inputWorkflowMeta.listParameters();
 
@@ -238,7 +238,7 @@ public class ActionWorkflowDialog extends ActionBaseDialog implements IActionDia
 
   protected void pickFileVFS() {
     HopWorkflowFileType<WorkflowMeta> workflowFileType = new HopWorkflowFileType<>();
-    BaseDialog.presentFileDialog( shell, wPath, workflowMeta, workflowFileType.getFilterExtensions(), workflowFileType.getFilterNames(), true );
+    BaseDialog.presentFileDialog( shell, wPath, this.getWorkflowMeta(), workflowFileType.getFilterExtensions(), workflowFileType.getFilterNames(), true );
   }
 
   public void dispose() {
@@ -296,7 +296,7 @@ public class ActionWorkflowDialog extends ActionBaseDialog implements IActionDia
     wFollowingAbortRemotely.setSelection( action.isFollowingAbortRemotely() );
 
     try {
-      List<String> runConfigurations = metadataProvider.getSerializer( WorkflowRunConfiguration.class ).listObjectNames();
+      List<String> runConfigurations = this.getMetadataProvider().getSerializer( WorkflowRunConfiguration.class ).listObjectNames();
 
       try {
         ExtensionPointHandler.callExtensionPoint( HopGui.getInstance().getLog(), HopExtensionPoint.HopUiRunConfiguration.id, new Object[] { runConfigurations, WorkflowMeta.XML_TAG } );


### PR DESCRIPTION
- Remove the variable "action" in the parent ActionDialog  and keep only the typed variable in the child
- Protect ActionDialog variables (except "props")
- Add method ActionDialog.getWorkflowMeta()
- Remove unused variable from ActionDialog
- Rename some variables jobEntry -> action
- Rename some tests class WorkflowEntry -> WorkflowAction