### PR TITLE
HOP-2125 Fix ContextDialog scrollbar when opening

### DIFF
--- a/ui/src/main/java/org/apache/hop/ui/core/dialog/ContextDialog.java
+++ b/ui/src/main/java/org/apache/hop/ui/core/dialog/ContextDialog.java
@@ -280,19 +280,19 @@ public class ContextDialog extends Dialog {
 		} );
 		wCanvas.addKeyListener( keyAdapter );
 
-		// Filter all actions by default
-		//
-		this.filter( null );
-
-		// Force focus on the search bar
-		//
-		wSearch.setFocus();
-
 		// Show the dialog now
 		//
 		shell.layout();
 		shell.open();
 
+		// Filter all actions by default
+		//
+		this.filter( null );
+				
+		// Force focus on the search bar
+		//
+		wSearch.setFocus();
+		
 		// Wait until the dialog is closed
 		//
 		while ( !shell.isDisposed() ) {


### PR DESCRIPTION
I force a refresh after opening the shell. 
Works well on Windows, but must be tested on another operating system