### PR TITLE
adjusting classpath before InitialContext creation

### DIFF
--- a/plugins/transforms/ldap/src/main/java/org/apache/hop/pipeline/transforms/ldapinput/LdapProtocol.java
+++ b/plugins/transforms/ldap/src/main/java/org/apache/hop/pipeline/transforms/ldapinput/LdapProtocol.java
@@ -35,6 +35,7 @@ import org.apache.hop.core.logging.ILogChannel;
 import org.apache.hop.core.util.Utils;
 import org.apache.hop.core.variables.IVariables;
 import org.apache.hop.i18n.BaseMessages;
+import org.apache.hop.pipeline.transforms.ldapinput.store.CustomSocketFactory;
 
 /** Class encapsulating Ldap protocol configuration */
 public class LdapProtocol {
@@ -121,7 +122,19 @@ public class LdapProtocol {
 
   protected InitialLdapContext createLdapContext(Hashtable<String, String> env)
       throws NamingException {
-    return new InitialLdapContext(env, null);
+    System.out.println("LdapProtocol.createLdapContext()");
+    CustomSocketFactory.printClasspath();
+    ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+    InitialLdapContext context = null;
+    try {
+        Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
+        CustomSocketFactory.printClasspath();
+        new InitialLdapContext(env, null);
+    } finally {
+        Thread.currentThread().setContextClassLoader(originalClassLoader);
+    }
+    
+    return context;
   }
 
   protected void doConnect(String username, String password) throws HopException {
@@ -158,6 +171,7 @@ public class LdapProtocol {
       }
 
     } catch (Exception e) {
+      e.printStackTrace();
       throw new HopException(
           BaseMessages.getString(
               classFromResourcesPackage, "LDAPinput.Exception.ErrorConnecting", e.getMessage()),

--- a/plugins/transforms/ldap/src/main/java/org/apache/hop/pipeline/transforms/ldapinput/store/CustomSocketFactory.java
+++ b/plugins/transforms/ldap/src/main/java/org/apache/hop/pipeline/transforms/ldapinput/store/CustomSocketFactory.java
@@ -24,9 +24,12 @@ package org.apache.hop.pipeline.transforms.ldapinput.store;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.Socket;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.security.KeyManagementException;
 import java.security.KeyStore;
 import java.security.NoSuchAlgorithmException;
+import java.util.Collections;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
@@ -59,8 +62,11 @@ public class CustomSocketFactory extends SSLSocketFactory {
   }
 
   public static synchronized CustomSocketFactory getDefault() {
+    System.out.println("CustomSocketFactory.getDefault()" + trustManagers);
     if (!configured) {
       throw new IllegalStateException();
+    }else {
+      configure();
     }
 
     SSLContext ctx;
@@ -89,18 +95,31 @@ public class CustomSocketFactory extends SSLSocketFactory {
         keyStore = KeyStore.getInstance("JKS");
       }
     } catch (Exception e) {
+      e.printStackTrace();
       throw new HopException(
           BaseMessages.getString(PKG, "HopTrustManager.Exception.CouldNotCreateCertStore"), e);
     }
 
     trustManagers = new HopTrustManager[] {new HopTrustManager(keyStore, path, password)};
     configured = true;
+    System.out.println("CustomSocketFactory configured to trust given signer" + trustManagers);
+  }
+
+  public static void printClasspath() {
+    System.out.println(String.join("", Collections.nCopies(80, "*")));
+    System.out.println("Classpath for this thread: ");
+    URL[] urls = ((URLClassLoader) (Thread.currentThread().getContextClassLoader())).getURLs();
+    for (URL url: urls) {
+      System.out.println(url.getFile());
+    }
+    System.out.println(String.join("", Collections.nCopies(80, "*")));
   }
 
   /** Configures this SSLSocketFactory so that it trusts any signer. */
   public static synchronized void configure() {
     trustManagers = ALWAYS_TRUST_MANAGER;
     configured = true;
+    System.out.println("CustomSocketFactory configured to trust any signer"  + trustManagers);
   }
 
   @Override


### PR DESCRIPTION
**This PR is not meant to be merged.**

In LDAP SSL connection used, HOP [throwing exception](https://chat.project-hop.org/hop/pl/4dib4a9xn7yodn5o49bh39ww4r) 

```
HopException: 
Error trying to connect to LDAP host.Exception : 
javax.naming.CommunicationException: my-ldap:1636 [Root exception is java.lang.ClassNotFoundException: org.apache.hop.pipeline.transforms.ldapinput.store.CustomSocketFactory]
```

It turns out, When `new InitialContext(...)` called, it does not have the classpath to the plugins. So it fails to find classes.
This PR has code which resolves that problem by putting the classpath for the class to the thread classloader.

It does solve the problem of finding class but shows next problem of ldap operations (search/insert).


